### PR TITLE
ROFO-25 Spring 가상 쓰레드 사용 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
   cloud:
     compatibility-verifier:
       enabled: false
+  threads:
+    virtual:
+      enabled: true
 server:
   error:
     whitelabel:


### PR DESCRIPTION
### 개요
- JDK 21을 쓰는 큰 이유중에 하나가 버츄얼 쓰레드를 접목시키기 위함인데 그걸 까먹었다

### 변경사항
- 요청 톰캣 쓰레드를 기존 쓰레드풀이 아닌 버츄얼 쓰레드를 쓰도록 수정

### 테스트
- 테스트 코드 추가여부 X
- 테스트 코드가 추가되지 않았다면 그 이유를 적어주세요.
  - 코드상의 변화가 없음 

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-25) 


### 리뷰어에게 하고 싶은 말
- 요거 적용한다고 생각하고 있다가 잊어버렸는데 방금 공부하다가 떠올라서 적용합니다 ㅋㅋㅋㅋ
