### PR TITLE
ROFO-30 RestClient 설정

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/BaseException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/BaseException.kt
@@ -1,0 +1,3 @@
+package kr.weit.roadyfoody.common.exception
+
+open class BaseException(val errorCode: ErrorCode, message: String?) : RuntimeException(message)

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/CustomExceptions.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/CustomExceptions.kt
@@ -1,5 +1,0 @@
-package kr.weit.roadyfoody.common.exception
-
-open class BaseException(val errorCode: ErrorCode, message: String) : RuntimeException(message)
-
-class UserNotFoundException(message: String) : BaseException(ErrorCode.NO_SUCH_ELEMENT, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -13,5 +13,5 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, -10008, "Payload too large"),
 
     // external API error 11000대
-    RETRIES_EXCEEDED_ERROR(HttpStatus.SERVICE_UNAVAILABLE, -11000, "외부 API 호출 재시도 횟수 초과"),
+    RETRIES_EXCEEDED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -11000, "외부 API 호출 재시도 횟수 초과"),
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -11,4 +11,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
     EXIST_RESOURCE(HttpStatus.CONFLICT, -10005, "Exist resource"),
     NOT_FOUND_DEFAULT_RESOURCE(HttpStatus.INTERNAL_SERVER_ERROR, -10007, "Not found default resource"),
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, -10008, "Payload too large"),
+
+    // external API error 11000대
+    RETRIES_EXCEEDED_ERROR(HttpStatus.SERVICE_UNAVAILABLE, -11000, "외부 API 호출 재시도 횟수 초과"),
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/RetriesExceededException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/RetriesExceededException.kt
@@ -1,0 +1,5 @@
+package kr.weit.roadyfoody.common.exception
+
+class RetriesExceededException(
+    message: String? = ErrorCode.RETRIES_EXCEEDED_ERROR.errorMessage,
+) : BaseException(ErrorCode.RETRIES_EXCEEDED_ERROR, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/global/client/RestClientConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/client/RestClientConfig.kt
@@ -1,0 +1,49 @@
+package kr.weit.roadyfoody.global.client
+
+import kr.weit.roadyfoody.test.application.client.TestClientInterface
+import org.springframework.boot.web.client.ClientHttpRequestFactories
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.JdkClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.support.RestClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import java.time.Duration
+
+@Configuration
+class RestClientConfig {
+    @Bean
+    fun testClientInterface(): TestClientInterface {
+        return creatClient("https://jsonplaceholder.typicode.com", TestClientInterface::class.java)
+    }
+
+    // Todo RestClient에 가상 쓰레드 지정
+    private fun <T> creatClient(
+        baseUrl: String,
+        clientClass: Class<T>,
+    ): T {
+        val requestSettings: ClientHttpRequestFactorySettings =
+            ClientHttpRequestFactorySettings.DEFAULTS
+                .withConnectTimeout(Duration.ofSeconds(1L))
+                .withReadTimeout(Duration.ofSeconds(5L))
+
+        val jdkClientHttpRequestFactory: JdkClientHttpRequestFactory =
+            ClientHttpRequestFactories.get(
+                JdkClientHttpRequestFactory::class.java,
+                requestSettings,
+            )
+
+        val restClient =
+            RestClient.builder()
+                .baseUrl(baseUrl)
+                .requestFactory(jdkClientHttpRequestFactory)
+                .requestInterceptor(RetryClientHttpRequestInterceptor())
+                .build()
+
+        val adapter = RestClientAdapter.create(restClient)
+        val factory = HttpServiceProxyFactory.builderFor(adapter).build()
+
+        return factory.createClient(clientClass)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/global/client/RestClientConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/client/RestClientConfig.kt
@@ -13,20 +13,26 @@ import java.time.Duration
 
 @Configuration
 class RestClientConfig {
-    @Bean
-    fun testClientInterface(): TestClientInterface {
-        return creatClient("https://jsonplaceholder.typicode.com", TestClientInterface::class.java)
+    companion object {
+        private const val CONNECT_TIME = 1L
+        private const val READ_TIME = 5L
+        private const val TEST_URL = "https://jsonplaceholder.typicode.com"
     }
 
-    // Todo RestClient에 가상 쓰레드 지정
+    @Bean
+    fun testClientInterface(): TestClientInterface {
+        return creatClient(TEST_URL, TestClientInterface::class.java)
+    }
+
     private fun <T> creatClient(
         baseUrl: String,
         clientClass: Class<T>,
     ): T {
+        // Todo. 가상 쓰레드를 사용하기 위해 API 비동기화를 위한 설정 추가 필요
         val requestSettings: ClientHttpRequestFactorySettings =
             ClientHttpRequestFactorySettings.DEFAULTS
-                .withConnectTimeout(Duration.ofSeconds(1L))
-                .withReadTimeout(Duration.ofSeconds(5L))
+                .withConnectTimeout(Duration.ofSeconds(CONNECT_TIME))
+                .withReadTimeout(Duration.ofSeconds(READ_TIME))
 
         val jdkClientHttpRequestFactory: JdkClientHttpRequestFactory =
             ClientHttpRequestFactories.get(

--- a/src/main/kotlin/kr/weit/roadyfoody/global/client/RetryClientHttpRequestInterceptor.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/client/RetryClientHttpRequestInterceptor.kt
@@ -1,28 +1,38 @@
 package kr.weit.roadyfoody.global.client
 
 import kr.weit.roadyfoody.common.exception.RetriesExceededException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.http.client.ClientHttpResponse
-import java.net.http.HttpRequest
 
 class RetryClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
-    private val attempts = 3
+    companion object {
+        private const val ATTEMPTS = 3
+        private const val ZERO = 0
+    }
+
+    private val log: Logger = LoggerFactory.getLogger(RetryClientHttpRequestInterceptor::class.java)
+
     private val retryableStatus = setOf(HttpStatus.TOO_MANY_REQUESTS)
 
     override fun intercept(
-        request: org.springframework.http.HttpRequest,
+        request: HttpRequest,
         body: ByteArray,
         execution: ClientHttpRequestExecution,
     ): ClientHttpResponse {
-        for (i in 0 until attempts) {
+        for (i in ZERO until ATTEMPTS) {
             val response = execution.execute(request, body)
             if (!retryableStatus.contains(response.statusCode)) {
-                // Todo 로그 추가 필요할까요?
+                // Todo. ES에 사용하기 위해 json 형태 필요
+                log.info("Successful attempt: $i")
                 return response
             }
         }
+        log.error("Retries exceeded")
         throw RetriesExceededException()
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/global/client/RetryClientHttpRequestInterceptor.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/client/RetryClientHttpRequestInterceptor.kt
@@ -1,0 +1,28 @@
+package kr.weit.roadyfoody.global.client
+
+import kr.weit.roadyfoody.common.exception.RetriesExceededException
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+import java.net.http.HttpRequest
+
+class RetryClientHttpRequestInterceptor : ClientHttpRequestInterceptor {
+    private val attempts = 3
+    private val retryableStatus = setOf(HttpStatus.TOO_MANY_REQUESTS)
+
+    override fun intercept(
+        request: org.springframework.http.HttpRequest,
+        body: ByteArray,
+        execution: ClientHttpRequestExecution,
+    ): ClientHttpResponse {
+        for (i in 0 until attempts) {
+            val response = execution.execute(request, body)
+            if (!retryableStatus.contains(response.statusCode)) {
+                // Todo 로그 추가 필요할까요?
+                return response
+            }
+        }
+        throw RetriesExceededException()
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/test/application/client/TestClientInterface.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/test/application/client/TestClientInterface.kt
@@ -1,0 +1,12 @@
+package kr.weit.roadyfoody.test.application.client
+
+import org.springframework.stereotype.Component
+import org.springframework.web.service.annotation.GetExchange
+import org.springframework.web.service.annotation.HttpExchange
+
+@Component
+@HttpExchange
+interface TestClientInterface {
+    @GetExchange("/todos/1")
+    fun getTodo(): TodoResponse
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/test/application/client/TodoResponse.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/test/application/client/TodoResponse.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.test.application.client
+
+data class TodoResponse(
+    val userId: Int,
+    val id: Int,
+    val title: String,
+    val completed: Boolean,
+)

--- a/src/main/kotlin/kr/weit/roadyfoody/test/presentation/api/TestController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/test/presentation/api/TestController.kt
@@ -1,5 +1,7 @@
 package kr.weit.roadyfoody.test.presentation.api
 
+import kr.weit.roadyfoody.test.application.client.TestClientInterface
+import kr.weit.roadyfoody.test.application.client.TodoResponse
 import kr.weit.roadyfoody.test.presentation.spec.TestControllerSpec
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -9,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController
 // 나중에 여러분들이 작업을 시작하게되면 이 컨트롤러는 삭제해주세요
 @RestController
 @RequestMapping("/api/v1/test")
-class TestController : TestControllerSpec {
+class TestController(
+    val testClientInterface: TestClientInterface,
+) : TestControllerSpec {
     @GetMapping("/success")
     override fun success(name: String): String {
         return "Hello $name!"
@@ -23,5 +27,10 @@ class TestController : TestControllerSpec {
     @GetMapping("/filter")
     override fun filter(): String {
         return "success filter"
+    }
+
+    @GetMapping("/rest")
+    fun rest(): TodoResponse {
+        return testClientInterface.getTodo()
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/test/presentation/api/TestController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/test/presentation/api/TestController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/test")
 class TestController(
-    val testClientInterface: TestClientInterface,
+    private val testClientInterface: TestClientInterface,
 ) : TestControllerSpec {
     @GetMapping("/success")
     override fun success(name: String): String {

--- a/src/main/kotlin/kr/weit/roadyfoody/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/exception/UserNotFoundException.kt
@@ -1,0 +1,6 @@
+package kr.weit.roadyfoody.user.exception
+
+import kr.weit.roadyfoody.common.exception.BaseException
+import kr.weit.roadyfoody.common.exception.ErrorCode
+
+class UserNotFoundException(message: String) : BaseException(ErrorCode.NO_SUCH_ELEMENT, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/user/repository/UserRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package kr.weit.roadyfoody.user.repository
 
-import kr.weit.roadyfoody.common.exception.UserNotFoundException
 import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.exception.UserNotFoundException
 import org.springframework.data.jpa.repository.JpaRepository
 
 fun UserRepository.getByUserId(userId: Long): User = findById(userId).orElseThrow { UserNotFoundException("$userId ID 의 사용자는 존재하지 않습니다.") }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/security/config/SecurityConfig.kt
@@ -39,6 +39,7 @@ private val PERMITTED_URL_PATTERNS =
         "/ready",
         "/api/v1/test/success",
         "/api/v1/test/error",
+        "/api/v1/test/rest",
         "/swagger-ui/**",
         "/v3/api-docs/**",
         "/actuator/prometheus",

--- a/src/test/kotlin/kr/weit/roadyfoody/test/controller/TestControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/test/controller/TestControllerTest.kt
@@ -8,6 +8,7 @@ import kr.weit.roadyfoody.test.presentation.api.TestController
 import kr.weit.roadyfoody.user.security.config.SecurityConfig
 import kr.weit.roadyfoody.user.security.handler.CustomAuthenticationEntryPoint
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
@@ -20,7 +21,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(TestController::class)
 class TestControllerTest(
     private val mockMvc: MockMvc,
-    private val testClientInterface: TestClientInterface,
+    @MockBean private val testClientInterface: TestClientInterface,
 ) : BehaviorSpec({
         given("Header에 userid가 있는 경우") {
             `when`("/api/v1/test/filter GET 요청하면") {

--- a/src/test/kotlin/kr/weit/roadyfoody/test/controller/TestControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/test/controller/TestControllerTest.kt
@@ -3,6 +3,7 @@ package kr.weit.roadyfoody.test.controller
 import io.kotest.core.spec.style.BehaviorSpec
 import kr.weit.roadyfoody.global.jsonmapper.ObjectMapperProvider
 import kr.weit.roadyfoody.global.log.TraceManager
+import kr.weit.roadyfoody.test.application.client.TestClientInterface
 import kr.weit.roadyfoody.test.presentation.api.TestController
 import kr.weit.roadyfoody.user.security.config.SecurityConfig
 import kr.weit.roadyfoody.user.security.handler.CustomAuthenticationEntryPoint
@@ -19,6 +20,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(TestController::class)
 class TestControllerTest(
     private val mockMvc: MockMvc,
+    private val testClientInterface: TestClientInterface,
 ) : BehaviorSpec({
         given("Header에 userid가 있는 경우") {
             `when`("/api/v1/test/filter GET 요청하면") {

--- a/src/test/kotlin/kr/weit/roadyfoody/user/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/repository/UserRepositoryTest.kt
@@ -3,9 +3,9 @@ package kr.weit.roadyfoody.user.repository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import kr.weit.roadyfoody.common.exception.UserNotFoundException
 import kr.weit.roadyfoody.support.annotation.RepositoryTest
 import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.exception.UserNotFoundException
 import kr.weit.roadyfoody.user.fixture.TEST_NONEXISTENT_ID
 import kr.weit.roadyfoody.user.fixture.TEST_NONEXISTENT_NICKNAME
 import kr.weit.roadyfoody.user.fixture.createTestUser1


### PR DESCRIPTION
### 개요

### 변경사항
* UserNotFoundException과 같은 도메인 전용 Exception은 해당 도메인 User 패키지 아래에서 관리
* RestClient의 timeout 설정
* RetryIntercaptor 외부 API에게 Too Many Requests 상태 코드를 반환받을 시 API 요청 재시도 로직
* RetriesExceededException 재시도 실패 에러 생성


### 테스트
- 테스트 코드 추가여부 O/X x
- 테스트 코드가 추가되지 않았다면 그 이유를 적어주세요.
RestClient관련 test 문서 찾아보고 추가할 수 있으면 추가하겠습니다!

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-30) 


### 리뷰어에게 하고 싶은 말
1. log를 그냥 log.info log.error이렇게 찍으면 될까요?? log/trace 부분을 아직 파악하지 못해 로그를 어떻게 찍으면 좋을지 궁금합니다.
2. restClient를 추가하시려면
RestClient에서 baseUrl이랑 interface 빈 설정하시면 됩니다.


3. 찾아보니 restClient 부분에 [가상쓰레드](https://0soo.tistory.com/261#RestClient%EC%--%--%--%EA%B-%--%EC%--%--%--%EC%-A%A-%EB%A-%--%EB%--%-C%--%ED%-C%A-%ED%--%A-%EB%A-%AC%--%EC%A-%--%EC%A-%--%ED%--%--%EA%B-%B-) 지정을 하던데 해당 부분 도입해도 괜찮을까요?