### PR TITLE
ROFO-36 Swagger Authorize UI 적용

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
@@ -1,7 +1,10 @@
 package kr.weit.roadyfoody.global.swagger.config
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -22,11 +25,31 @@ class ApiDocsConfig {
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
-            .info(
-                Info()
-                    .title("로디푸디 API")
-                    .description("로디푸디 API 문서입니다.")
-                    .version("1.0.0"),
-            )
+            .info(createApiInfo())
+            .components(createSecurityComponents())
+            .addSecurityItem(createSecurityRequirement())
+    }
+
+    private fun createApiInfo(): Info {
+        return Info()
+            .title("로디푸디 API")
+            .description("로디푸디 API 문서입니다.")
+            .version("1.0.0")
+    }
+
+    // TODO 회원가입 기능 개발 후 수정 혹은 삭제 고려
+    private fun createSecurityComponents(): Components {
+        return Components().addSecuritySchemes(
+            "userIdHeader",
+            SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .`in`(SecurityScheme.In.HEADER)
+                .name("userId"),
+        )
+    }
+
+    // TODO 회원가입 기능 개발 후 수정 혹은 삭제 고려
+    private fun createSecurityRequirement(): SecurityRequirement {
+        return SecurityRequirement().addList("userIdHeader")
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/test/presentation/spec/TestControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/test/presentation/spec/TestControllerSpec.kt
@@ -2,7 +2,6 @@ package kr.weit.roadyfoody.test.presentation.spec
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.tags.Tag
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 
@@ -22,16 +21,6 @@ interface TestControllerSpec {
     @Operation(description = "에러 테스트 API")
     fun error(): String
 
-    @Operation(
-        description = "필터 테스트 API",
-        parameters = [
-            Parameter(
-                `in` = ParameterIn.HEADER,
-                name = "userId",
-                description = "개발 시 임의 로그인 처리를 위한 아무 유저 ID 값",
-                required = true,
-            ),
-        ],
-    )
+    @Operation(description = "필터 테스트 API")
     fun filter(): String
 }


### PR DESCRIPTION
### 개요
현재 방식은 API 스웨거 문서 작성 시 `userId` 를 매번 명시해야 하는데 이것이 번거롭게 느껴져 스웨거 인증 기능을 적용하기로 마음 먹었습니다.

### 변경사항
- `ApiDocsConfig.kt` 에 `userId` 를 보안 인증 요소로 추가하였습니다.
- `userId` 를 API Spec 필수 패러미터 에서 지웠습니다.


### 테스트
- 테스트 코드 추가여부 X
- 비즈니스 로직 상 변경이 없습니다.

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-36) 


### 리뷰어에게 하고 싶은 말
잘 부탁드리겠습니다!
sandbox API 문서에서 test filter API 시도 시 정상작동하였습니다!