### PR TITLE
ROFO-75 User nickname 유효 범위 증가 (한글 자/모음 추가)

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
@@ -2,6 +2,6 @@ package kr.weit.roadyfoody.user.utils
 
 const val NICKNAME_MIN_LENGTH = 6
 const val NICKNAME_MAX_LENGTH = 16
-const val NICKNAME_REGEX_STR = "^(?:[\\u1100-\\u1112\\u1161-\\u1175]|[ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9]){$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}$"
+const val NICKNAME_REGEX_STR = "^[ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9]{$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}\$"
 val NICKNAME_REGEX = Regex(NICKNAME_REGEX_STR)
 const val NICKNAME_REGEX_DESC = "닉네임은 $NICKNAME_MIN_LENGTH 자 이상 $NICKNAME_MAX_LENGTH 자 이하의 한글, 영문, 숫자 여야 합니다."

--- a/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
@@ -2,6 +2,6 @@ package kr.weit.roadyfoody.user.utils
 
 const val NICKNAME_MIN_LENGTH = 6
 const val NICKNAME_MAX_LENGTH = 16
-const val NICKNAME_REGEX_STR = "^[A-Za-z0-9가-힣]{$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}$"
+const val NICKNAME_REGEX_STR = "^(?:[\\u1100-\\u1112\\u1161-\\u1175]|[ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9]){$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}$"
 val NICKNAME_REGEX = Regex(NICKNAME_REGEX_STR)
 const val NICKNAME_REGEX_DESC = "닉네임은 $NICKNAME_MIN_LENGTH 자 이상 $NICKNAME_MAX_LENGTH 자 이하의 한글, 영문, 숫자 여야 합니다."

--- a/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/utils/NickNameRegex.kt
@@ -2,6 +2,6 @@ package kr.weit.roadyfoody.user.utils
 
 const val NICKNAME_MIN_LENGTH = 6
 const val NICKNAME_MAX_LENGTH = 16
-const val NICKNAME_REGEX_STR = "^[ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9]{$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}\$"
+const val NICKNAME_REGEX_STR = "^[ㄱ-ㅎㅏ-ㅣ가-힣A-Za-z0-9]{$NICKNAME_MIN_LENGTH,$NICKNAME_MAX_LENGTH}$"
 val NICKNAME_REGEX = Regex(NICKNAME_REGEX_STR)
 const val NICKNAME_REGEX_DESC = "닉네임은 $NICKNAME_MIN_LENGTH 자 이상 $NICKNAME_MAX_LENGTH 자 이하의 한글, 영문, 숫자 여야 합니다."

--- a/src/test/kotlin/kr/weit/roadyfoody/user/domain/UserTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/domain/UserTest.kt
@@ -19,11 +19,14 @@ class UserTest :
                 then("User 을 반환한다.") {
                     forAll(
                         row(TEST_MIN_LENGTH_NICKNAME),
+                        row("ㄱ".repeat(NICKNAME_MIN_LENGTH)),
+                        row("testㄱㄴㄷ"),
                         row("ABCDEF"),
                         row("123456"),
                         row("테스터테스터"),
                         row("tester1234"),
                         row("테스터테스터123456"),
+                        row("ㄱ".repeat(NICKNAME_MAX_LENGTH)),
                         row(TEST_MAX_LENGTH_NICKNAME),
                     ) {
                             nickname ->


### PR DESCRIPTION
### 개요
기존 닉네임은 한글 중 완성형 한글만을 허용했습니다. 하지만
기획 상 닉네임에서 한글 자/모음 또한 하나의 글자로 취급하는 것이 맞다 판단하여 추가하였습니다.

### 변경사항
- Nickname 정규표현식 수정
- 자/모음으로 구성된 테스트 케이스 추가

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-75) 


### 리뷰어에게 하고 싶은 말
피드백 감사히 받겠습니다!