### PR TITLE
ROFO-86 회원가입, 토큰 갱신 API 피드백 반영

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
@@ -2,6 +2,7 @@ package kr.weit.roadyfoody.auth.presentation.spec
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
@@ -96,7 +97,7 @@ interface AuthControllerSpec {
                                 summary = "SocialAccessToken 미입력",
                                 value = """
                         {
-                            "code": -10000,
+                            "code": -10001,
                             "errorMessage": "SocialAccessToken 이 존재하지 않습니다."
                         }
                         """,
@@ -142,14 +143,13 @@ interface AuthControllerSpec {
         signUpRequest: SignUpRequest,
         @Schema(
             description = "프로필 이미지. 최대 1MB, WEBP 형식만 가능합니다. 이미지가 없을 시 하단 체크박스는 해제해주세요.",
-            required = false,
             type = "string",
             format = "binary",
         )
         @MaxFileSize
         @WebPImage
         profileImage: MultipartFile?,
-    )
+    ): ServiceTokensResponse
 
     @Operation(
         summary = "닉네임 중복 검사 API",
@@ -277,16 +277,6 @@ interface AuthControllerSpec {
                         """,
                             ),
                             ExampleObject(
-                                name = "Invalid Refresh Token Format",
-                                summary = "RefreshToken 형식 오류",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "RefreshToken 의 형식이 올바르지 않습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
                                 name = "Invalid Refresh Token",
                                 summary = "유효하지 않은 RefreshToken",
                                 value = """
@@ -303,7 +293,12 @@ interface AuthControllerSpec {
         ],
     )
     fun refresh(
-        @Parameter(hidden = true)
+        @Parameter(
+            name = "token",
+            description = "리프레시 토큰 (Bearer 같은 형식 표기없이 전달해주세요. 예: eyJhbGciOiJ9.eyJzdWIiOiJ0ZXN0QGdtYWlsLmNvbSIsImV4cCI6MTY0NzQwNjQwNn0.1",
+            required = true,
+            `in` = ParameterIn.QUERY,
+        )
         refreshToken: String?,
     ): ServiceTokensResponse
 

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthIntegrationServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthIntegrationServiceTest.kt
@@ -66,33 +66,31 @@ class AuthIntegrationServiceTest(
             s3Template.deleteBucket(s3Properties.bucket)
         }
 
-        given("프로필 사진이 존재하는 경우") {
-            `when`("회원가입을 요청하면") {
+        given("register 테스트") {
+            `when`("프로필 사진이 존재하는 경우") {
                 then("회원가입이 성공한다") {
                     val signUpRequest = createTestSignUpRequest(termIdSet = validTermIdSet)
-                    authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, signUpRequest, createTestImageFile(WEBP))
+                    val tokensResponse = authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, signUpRequest, createTestImageFile(WEBP))
                     val profileImageName = userRepository.getByNickname(signUpRequest.nickname).profile.profileImageName
+                    tokensResponse.shouldNotBeNull()
                     profileImageName.shouldNotBeNull()
                     s3Template.objectExists(s3Properties.bucket, profileImageName).shouldBeTrue()
                     verify(exactly = 1) { authQueryService.requestKakaoUserInfo(any<String>()) }
                 }
             }
-        }
 
-        given("프로필 사진이 존재하지 않는 경우") {
-            `when`("회원가입을 요청하면") {
+            `when`("프로필 사진이 존재하지 않는 경우") {
                 then("회원가입이 성공한다") {
                     val signUpRequest = createTestSignUpRequest(termIdSet = validTermIdSet)
-                    authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, signUpRequest, null)
+                    val tokensResponse = authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, signUpRequest, null)
                     val profileImageName = userRepository.getByNickname(signUpRequest.nickname).profile.profileImageName
+                    tokensResponse.shouldNotBeNull()
                     profileImageName.shouldBeNull()
                     verify(exactly = 1) { authQueryService.requestKakaoUserInfo(any<String>()) }
                 }
             }
-        }
 
-        given("필수약관을 동의하지 않은 경우") {
-            `when`("회원가입을 요청하면") {
+            `when`("필수약관을 동의하지 않은 경우") {
                 then("RequiredTermNotAgreedException 을 던진다") {
                     shouldThrow<RequiredTermNotAgreedException> {
                         authCommandService.register(
@@ -104,14 +102,10 @@ class AuthIntegrationServiceTest(
                     verify(exactly = 1) { authQueryService.requestKakaoUserInfo(any<String>()) }
                 }
             }
-        }
 
-        given("이미 가입된 사용자인 경우") {
-            beforeEach {
-                userRepository.save(createTestUser(socialId = TEST_USER_SOCIAL_ID))
-            }
-            `when`("회원가입을 요청하면") {
+            `when`("이미 가입된 사용자인 경우") {
                 then("UserAlreadyExistsException 을 던진다") {
+                    userRepository.save(createTestUser(socialId = TEST_USER_SOCIAL_ID))
                     shouldThrow<UserAlreadyExistsException> {
                         authCommandService.register(
                             TEST_SOCIAL_ACCESS_TOKEN,
@@ -122,14 +116,10 @@ class AuthIntegrationServiceTest(
                     verify(exactly = 1) { authQueryService.requestKakaoUserInfo(any<String>()) }
                 }
             }
-        }
 
-        given("중복된 닉네임인 경우") {
-            beforeEach {
-                userRepository.save(createTestUser(nickname = TEST_USER_NICKNAME))
-            }
-            `when`("회원가입을 요청하면") {
+            `when`("중복된 닉네임인 경우") {
                 then("UserAlreadyExistsException 을 던진다") {
+                    userRepository.save(createTestUser(nickname = TEST_USER_NICKNAME))
                     shouldThrow<UserAlreadyExistsException> {
                         authCommandService.register(
                             TEST_SOCIAL_ACCESS_TOKEN,
@@ -142,7 +132,7 @@ class AuthIntegrationServiceTest(
             }
         }
 
-        given("login 메소드") {
+        given("login 테스트") {
             `when`("유효한 socialAccessToken 을 전달하면") {
                 then("로그인이 성공한다") {
                     authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, createTestSignUpRequest(termIdSet = validTermIdSet), null)
@@ -156,7 +146,7 @@ class AuthIntegrationServiceTest(
             }
         }
 
-        given("reissueTokens 메소드") {
+        given("reissueTokens 테스트") {
             lateinit var tokensResponse: ServiceTokensResponse
             lateinit var user: User
             beforeEach {
@@ -199,7 +189,7 @@ class AuthIntegrationServiceTest(
             }
         }
 
-        given("logout 메소드") {
+        given("logout 테스트") {
             `when`("Refresh Token 이 캐시에 저장되어있다면") {
                 then("이를 제거하고 로그아웃이 성공한다") {
                     authCommandService.register(TEST_SOCIAL_ACCESS_TOKEN, createTestSignUpRequest(termIdSet = validTermIdSet), null)

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/fixture/AuthDtoFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/fixture/AuthDtoFixture.kt
@@ -37,7 +37,6 @@ val TEST_ACCESS_TOKEN = generateHmac256Key()
 val TEST_REFRESH_TOKEN = generateHmac256Key()
 
 val TEST_BEARER_ACCESS_TOKEN = "Bearer $TEST_ACCESS_TOKEN"
-val TEST_BEARER_REFRESH_TOKEN = "Bearer $TEST_REFRESH_TOKEN"
 
 fun createTestTokensResponse(): ServiceTokensResponse =
     ServiceTokensResponse(

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthControllerTest.kt
@@ -16,7 +16,6 @@ import kr.weit.roadyfoody.auth.application.service.AuthCommandService
 import kr.weit.roadyfoody.auth.application.service.AuthQueryService
 import kr.weit.roadyfoody.auth.fixture.PROFILE_IMAGE_FILE_NAME
 import kr.weit.roadyfoody.auth.fixture.SIGN_UP_REQUEST_FILE_NAME
-import kr.weit.roadyfoody.auth.fixture.TEST_BEARER_REFRESH_TOKEN
 import kr.weit.roadyfoody.auth.fixture.TEST_BEARER_SOCIAL_ACCESS_TOKEN
 import kr.weit.roadyfoody.auth.fixture.TEST_REFRESH_TOKEN
 import kr.weit.roadyfoody.auth.fixture.createTestSignUpRequest
@@ -53,9 +52,10 @@ class AuthControllerTest(
         val requestPath = "/api/v1/auth"
 
         given("POST $requestPath") {
+            val tokensResponse = createTestTokensResponse()
             `when`("WEBP 이미지 프로필 사진을 업로드하면") {
-                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } just runs
-                then("회원가입에 성공하고 201 상태번호를 반환한다") {
+                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } returns tokensResponse
+                then("201 상태번호와 ServiceTokensResponse 를 반환한다") {
                     mockMvc.perform(
                         multipart(requestPath)
                             .file(createTestImageFile(WEBP))
@@ -67,14 +67,18 @@ class AuthControllerTest(
                             )
                             .header(AUTHORIZATION, TEST_BEARER_SOCIAL_ACCESS_TOKEN)
                             .contentType(MediaType.MULTIPART_FORM_DATA),
-                    ).andExpect(status().isCreated)
+                    )
+                        .andExpect(status().isCreated)
+                        .andExpect(
+                            content().json(objectMapper.writeValueAsString(tokensResponse)),
+                        )
                     verify(exactly = 1) { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) }
                 }
             }
 
             `when`("프로필사진을 업로드하지 않아도") {
-                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } just runs
-                then("회원가입에 성공하고 201 상태번호를 반환한다") {
+                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } returns tokensResponse
+                then("201 상태번호와 ServiceTokensResponse 를 반환한다") {
                     mockMvc.perform(
                         multipart(requestPath)
                             .file(
@@ -85,13 +89,17 @@ class AuthControllerTest(
                             )
                             .header(AUTHORIZATION, TEST_BEARER_SOCIAL_ACCESS_TOKEN)
                             .contentType(MediaType.MULTIPART_FORM_DATA),
-                    ).andExpect(status().isCreated)
+                    )
+                        .andExpect(status().isCreated)
+                        .andExpect(
+                            content().json(objectMapper.writeValueAsString(tokensResponse)),
+                        )
                     verify(exactly = 1) { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) }
                 }
             }
 
             `when`("WEBP 이미지가 아닌 프로필 사진을 업로드하면") {
-                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } just runs
+                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } returns mockk()
                 then("회원가입에 실패하고 400 상태번호를 반환한다") {
                     forAll(
                         row(JPEG),
@@ -116,7 +124,7 @@ class AuthControllerTest(
             }
 
             `when`("파일의 크기가 1MB를 초과하면") {
-                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } just runs
+                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } returns mockk()
                 val mockFile: MockMultipartFile = mockk<MockMultipartFile>()
                 every { mockFile.size } returns 1024 * 1024 + 1
                 every { mockFile.name } returns PROFILE_IMAGE_FILE_NAME
@@ -141,7 +149,7 @@ class AuthControllerTest(
             }
 
             `when`("소셜 로그인 AccessToken 이 없으면") {
-                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } just runs
+                every { authCommandService.register(any<String>(), any<SignUpRequest>(), any<MultipartFile>()) } returns mockk()
                 then("회원가입에 실패하고 401 상태번호를 반환한다") {
                     mockMvc.perform(
                         multipart(requestPath)
@@ -230,7 +238,7 @@ class AuthControllerTest(
                 then("200 상태번호와 ServiceTokensResponse 를 반환한다") {
                     mockMvc.perform(
                         get("$requestPath/refresh")
-                            .header(AUTHORIZATION, TEST_BEARER_REFRESH_TOKEN),
+                            .param("token", TEST_REFRESH_TOKEN),
                     )
                         .andExpect(status().isOk)
                         .andExpect {
@@ -247,17 +255,6 @@ class AuthControllerTest(
                 then("400 상태번호를 반환한다") {
                     mockMvc.perform(
                         get("$requestPath/refresh"),
-                    ).andExpect(status().isBadRequest)
-                    verify(exactly = 0) { authCommandService.reissueTokens(any()) }
-                }
-            }
-
-            `when`("Bearer 토큰이 아니라면") {
-                every { authCommandService.reissueTokens(any()) } returns mockk()
-                then("400 상태번호를 반환한다") {
-                    mockMvc.perform(
-                        get("$requestPath/refresh")
-                            .header(AUTHORIZATION, TEST_REFRESH_TOKEN),
                     ).andExpect(status().isBadRequest)
                     verify(exactly = 0) { authCommandService.reissueTokens(any()) }
                 }


### PR DESCRIPTION
### 개요
안드로이드 개발자분으로부터 피드백을 받아 반영했습니다.

### 변경사항
- 회원가입 시 별도의 로그인 진행없이 바로 AccessToken, RefreshToken 발행
- 토큰 갱신 시 RefreshToken 전달 방식 변경 (Authorization 헤더 -> token 쿼리파라미터)
- 불일치하는 부분 수정 및 스타일 통일

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-86) 


### 리뷰어에게 하고 싶은 말
피드백 감사히 받겠습니다! 