### PR TITLE
ROFO-79 리포트 내역 추가 테이블 설계

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -2,7 +2,11 @@ package kr.weit.roadyfoody.common.exception
 
 import org.springframework.http.HttpStatus
 
-enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage: String) {
+enum class ErrorCode(
+    val httpStatus: HttpStatus,
+    val code: Int,
+    val errorMessage: String,
+) {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, -10000, "Invalid request"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, -10001, "Unauthorized"),
     FORBIDDEN(HttpStatus.FORBIDDEN, -10002, "Forbidden"),
@@ -16,6 +20,16 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
 
     // Bad Request -10000으로 코드 통일
     SIZE_NON_POSITIVE(HttpStatus.BAD_REQUEST, -10000, "조회할 개수는 양수여야 합니다."),
+    LAST_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -10000, "마지막 ID는 양수여야 합니다."),
+    INVALID_LENGTH_FOOD_SPOTS_NAME(HttpStatus.BAD_REQUEST, -10000, "상호명은 1자 이상 20자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."),
+    INVALID_CHARACTERS_FOOD_SPOTS_NAME(HttpStatus.BAD_REQUEST, -10000, "설명은 1자 이상 100자 이하로 입력해주세요."),
+    LATITUDE_TOO_HIGH(HttpStatus.BAD_REQUEST, -10000, "경도는 180 이하여야 합니다."),
+    LATITUDE_TOO_LOW(HttpStatus.BAD_REQUEST, -10000, "경도는 -180 이상이어야 합니다."),
+    LONGITUDE_TOO_HIGH(HttpStatus.BAD_REQUEST, -10000, "위도는 180 이하여야 합니다."),
+    LONGITUDE_TOO_LOW(HttpStatus.BAD_REQUEST, -10000, "위도는 -180 이상이어야 합니다."),
+    IMAGES_TOO_MANY(HttpStatus.BAD_REQUEST, -10000, "이미지는 최대 3개까지 업로드할 수 있습니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, -10000, "하나 이상의 파일이 잘못 되었습니다."),
+    IMAGES_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, -10000, "하나 이상의 파일이 잘못 되었습니다."),
 
     // Search API error 11000대
     REST_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -11000, "외부 API 호출 중 에러 발생"),

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Index
+import jakarta.persistence.OneToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import kr.weit.roadyfoody.common.domain.BaseModifiableEntity
@@ -36,6 +37,10 @@ class FoodSpots(
     var storeClosure: Boolean,
     @Column(columnDefinition = "SDO_GEOMETRY", nullable = false)
     var point: Point,
+    @OneToMany(mappedBy = "foodSpots")
+    val operationHoursList: MutableList<FoodSpotsOperationHours>,
+    @OneToMany(mappedBy = "foodSpots")
+    val foodCategoriesList: MutableList<FoodSpotsFoodCategory>,
 ) : BaseModifiableEntity() {
     init {
         require(FOOD_SPOTS_NAME_REGEX.matches(name)) { FOOD_SPOTS_NAME_REGEX_DESC }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
@@ -1,6 +1,5 @@
 package kr.weit.roadyfoody.foodSpots.domain
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -48,8 +47,8 @@ class FoodSpotsHistory(
     val storeClosure: Boolean,
     @Column(columnDefinition = "SDO_GEOMETRY", nullable = false, updatable = false)
     val point: Point,
-    @OneToMany(mappedBy = "foodSpotsHistory", cascade = [CascadeType.PERSIST, CascadeType.REMOVE], orphanRemoval = true)
-    val reportOperationHours: List<ReportOperationHours> = mutableListOf(),
-    @OneToMany(mappedBy = "foodSpotsHistory", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val reportFoodCategories: List<ReportFoodCategory> = mutableListOf(),
+    @OneToMany(mappedBy = "foodSpotsHistory")
+    val operationHoursList: List<ReportOperationHours>,
+    @OneToMany(mappedBy = "foodSpotsHistory")
+    val foodCategoriesList: List<ReportFoodCategory>,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.foodSpots.domain
 
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -9,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import kr.weit.roadyfoody.common.domain.BaseTimeEntity
@@ -46,4 +48,8 @@ class FoodSpotsHistory(
     val storeClosure: Boolean,
     @Column(columnDefinition = "SDO_GEOMETRY", nullable = false, updatable = false)
     val point: Point,
+    @OneToMany(mappedBy = "foodSpotsHistory", cascade = [CascadeType.PERSIST, CascadeType.REMOVE], orphanRemoval = true)
+    val reportOperationHours: List<ReportOperationHours> = mutableListOf(),
+    @OneToMany(mappedBy = "foodSpotsHistory", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val reportFoodCategories: List<ReportFoodCategory> = mutableListOf(),
 ) : BaseTimeEntity()

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportFoodCategory.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportFoodCategory.kt
@@ -1,0 +1,34 @@
+package kr.weit.roadyfoody.foodSpots.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import kr.weit.roadyfoody.common.domain.BaseTimeEntity
+
+@Entity
+@Table(
+    name = "report_food_categories",
+)
+@SequenceGenerator(
+    name = "REPORT_FOOD_CATEGORIES_SEQ_GENERATOR",
+    sequenceName = "REPORT_FOOD_CATEGORIES_SEQ",
+    initialValue = 1,
+    allocationSize = 1,
+)
+class ReportFoodCategory(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "REPORT_FOOD_CATEGORIES_SEQ_GENERATOR")
+    val id: Long = 0L,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_spots_history_id")
+    val foodSpotsHistory: FoodSpotsHistory,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_categories_id")
+    val foodCategory: FoodCategory,
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportOperationHours.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportOperationHours.kt
@@ -1,0 +1,32 @@
+package kr.weit.roadyfoody.foodSpots.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.IdClass
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import kr.weit.roadyfoody.common.domain.BaseTimeEntity
+
+@Entity
+@Table(
+    name = "report_operation_hours",
+)
+@IdClass(ReportOperationHoursId::class)
+class ReportOperationHours(
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "food_spots_history_id")
+    val foodSpotsHistory: FoodSpotsHistory,
+    @Id
+    @Enumerated(EnumType.ORDINAL)
+    @Column(nullable = false, length = 1)
+    val dayOfWeek: DayOfWeek,
+    @Column(nullable = false, length = 5)
+    val openingHours: String,
+    @Column(nullable = false, length = 5)
+    val closingHours: String,
+) : BaseTimeEntity()

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportOperationHoursId.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/ReportOperationHoursId.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.foodSpots.domain
+
+import java.io.Serializable
+
+data class ReportOperationHoursId(
+    val foodSpotsHistory: FoodSpotsHistory,
+    val dayOfWeek: DayOfWeek,
+) : Serializable

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/dto/ReportDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/dto/ReportDtos.kt
@@ -16,7 +16,11 @@ import kr.weit.roadyfoody.user.domain.User
 import java.time.LocalDateTime
 
 data class ReportRequest(
-    @Schema(description = "상호명 : $FOOD_SPOTS_NAME_REGEX_DESC", example = "명륜진사갈비 본사")
+    @Schema(
+        description =
+            "상호명 : $FOOD_SPOTS_NAME_REGEX_DESC\t(허용된 특수문자 : 마침표 (.) 쉼표 (,) 작은따옴표 (') 가운데점 (·) 앰퍼샌드 (&) 하이픈 (-))",
+        example = "명륜진사갈비 본사",
+    )
     @field:Pattern(regexp = FOOD_SPOTS_NAME_REGEX_STR, message = FOOD_SPOTS_NAME_REGEX_DESC)
     @field:NotBlank(message = "상호명은 필수입니다.")
     val name: String,
@@ -45,6 +49,8 @@ data class ReportRequest(
             foodTruck = foodTruck,
             open = open,
             storeClosure = closed,
+            foodCategoriesList = mutableListOf(),
+            operationHoursList = mutableListOf(),
         )
 
     fun toFoodSpotsHistoryEntity(
@@ -58,6 +64,8 @@ data class ReportRequest(
         foodTruck = foodTruck,
         open = open,
         storeClosure = closed,
+        foodCategoriesList = mutableListOf(),
+        operationHoursList = mutableListOf(),
     )
 }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -11,11 +11,13 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 import kr.weit.roadyfoody.common.dto.SliceResponse
+import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.ErrorResponse
 import kr.weit.roadyfoody.foodSpots.dto.ReportHistoriesResponse
 import kr.weit.roadyfoody.foodSpots.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.utils.SliceReportHistories
 import kr.weit.roadyfoody.foodSpots.validator.WebPImageList
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PathVariable
@@ -33,118 +35,19 @@ interface FoodSportsControllerSpec {
                 responseCode = "201",
                 description = "리포트 성공",
             ),
-            ApiResponse(
-                responseCode = "400",
-                description = "리포트 실패",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Empty FoodSpot Name",
-                                summary = "음식점 이름 미입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "상호명은 1자 이상 20자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid FoodSpot Name",
-                                summary = "상호명에 허용되지 않은 특수문자가 포함된 경우",
-                                value = """
-                                {
-                                    "code": -10000,
-                                    "errorMessage": "상호명은 1자 이상 20자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."
-                                }
-                                """,
-                            ),
-                            ExampleObject(
-                                name = "FoodSpot Name Length Too Long",
-                                summary = "상호명이 30자 초과인 경우",
-                                value = """
-                            {
-                                "code": -10000,
-                                "errorMessage": "상호명은 1자 이상 20자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."
-                            }
-                            """,
-                            ),
-                            ExampleObject(
-                                name = "latitude too high",
-                                summary = "경도가 범위보다 높은 경우",
-                                value = """
-                            {
-                                "code": -10000,
-                                "errorMessage": "경도는 180 이하여야 합니다."
-                            }
-                            """,
-                            ),
-                            ExampleObject(
-                                name = "latitude too low",
-                                summary = "경도가 범위보다 낮은 경우",
-                                value = """
-                            {
-                                "code": -10000,
-                                "errorMessage": "경도는 -180 이상이어야 합니다."
-                            }
-                            """,
-                            ),
-                            ExampleObject(
-                                name = "longitude too high",
-                                summary = "위도가 범위보다 높은 경우",
-                                value = """
-                            {
-                                "code": -10000,
-                                "errorMessage": "위도는 180 이하여야 합니다."
-                            }
-                            """,
-                            ),
-                            ExampleObject(
-                                name = "longitude too low",
-                                summary = "위도가 범위보다 낮은 경우",
-                                value = """
-                            {
-                                "code": -10000,
-                                "errorMessage": "위도는 -180 이상여야 합니다."
-                            }
-                            """,
-                            ),
-                            ExampleObject(
-                                name = "Too Many Images",
-                                summary = "이미지가 3개 초과인 경우",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "이미지는 최대 3개까지 업로드할 수 있습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid Image type",
-                                summary = "WEBP 이외의 이미지 입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "하나 이상의 파일이 잘못 되었습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Too large image",
-                                summary = "이미지 용량이 1MB 초과인 경우",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "하나 이상의 파일이 잘못 되었습니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.INVALID_LENGTH_FOOD_SPOTS_NAME,
+            ErrorCode.INVALID_CHARACTERS_FOOD_SPOTS_NAME,
+            ErrorCode.LATITUDE_TOO_HIGH,
+            ErrorCode.LATITUDE_TOO_LOW,
+            ErrorCode.LONGITUDE_TOO_HIGH,
+            ErrorCode.LONGITUDE_TOO_LOW,
+            ErrorCode.IMAGES_TOO_MANY,
+            ErrorCode.INVALID_IMAGE_TYPE,
+            ErrorCode.IMAGES_SIZE_TOO_LARGE,
         ],
     )
     fun createReport(
@@ -180,39 +83,6 @@ interface FoodSportsControllerSpec {
                     ),
                 ],
             ),
-
-            ApiResponse(
-                responseCode = "400",
-                description = "리포트 리스트 조회 실패",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Invalid Size",
-                                summary = "양수가 아닌 사이즈 입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "조회할 개수는 양수여야 합니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid Last ID",
-                                summary = "양수가 아닌 마지막 ID 입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "마지막 ID는 양수여야 합니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
             ApiResponse(
                 responseCode = "404",
                 description = "리포트 리스트 조회 실패",
@@ -222,8 +92,8 @@ interface FoodSportsControllerSpec {
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "Not Found User",
-                                summary = "유저를 찾을 수 없음",
+                                name = "Not found user",
+                                summary = "NOT_FOUND_USER",
                                 value = """
                                 {
                                     "code": -10009,
@@ -235,6 +105,12 @@ interface FoodSportsControllerSpec {
                     ),
                 ],
             ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.SIZE_NON_POSITIVE,
+            ErrorCode.LAST_ID_NON_POSITIVE,
         ],
     )
     fun getReportHistories(

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/utils/FoodSpotsNameRegex.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/utils/FoodSpotsNameRegex.kt
@@ -1,6 +1,6 @@
 package kr.weit.roadyfoody.foodSpots.utils
 
 const val FOOD_SPOTS_NAME_MAX_LENGTH = 20
-const val FOOD_SPOTS_NAME_REGEX_STR = "^[가-힣a-zA-Z0-9.,'·&-]{1,${FOOD_SPOTS_NAME_MAX_LENGTH}}\$"
+const val FOOD_SPOTS_NAME_REGEX_STR = "^[가-힣a-zA-Z0-9.,'·&\\-\\s]{1,${FOOD_SPOTS_NAME_MAX_LENGTH}}\$"
 val FOOD_SPOTS_NAME_REGEX = Regex(FOOD_SPOTS_NAME_REGEX_STR)
 const val FOOD_SPOTS_NAME_REGEX_DESC = "상호명은 1자 이상 ${FOOD_SPOTS_NAME_MAX_LENGTH}자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/utils/FoodSpotsNameRegex.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/utils/FoodSpotsNameRegex.kt
@@ -1,6 +1,6 @@
 package kr.weit.roadyfoody.foodSpots.utils
 
 const val FOOD_SPOTS_NAME_MAX_LENGTH = 20
-const val FOOD_SPOTS_NAME_REGEX_STR = "^[가-힣a-zA-Z0-9!@#\$%^&*()_+=?\\s-]{1,${FOOD_SPOTS_NAME_MAX_LENGTH}}\$"
+const val FOOD_SPOTS_NAME_REGEX_STR = "^[가-힣a-zA-Z0-9.,'·&-]{1,${FOOD_SPOTS_NAME_MAX_LENGTH}}\$"
 val FOOD_SPOTS_NAME_REGEX = Regex(FOOD_SPOTS_NAME_REGEX_STR)
 const val FOOD_SPOTS_NAME_REGEX_DESC = "상호명은 1자 이상 ${FOOD_SPOTS_NAME_MAX_LENGTH}자 이하 한글, 영문, 숫자, 특수문자 여야 합니다."

--- a/src/main/resources/db/migration/V6__create_report_food_categories_and_operation_hours.sql
+++ b/src/main/resources/db/migration/V6__create_report_food_categories_and_operation_hours.sql
@@ -11,6 +11,8 @@ CREATE TABLE report_operation_hours
 ALTER TABLE report_operation_hours
     ADD CONSTRAINT FK_REPORT_OPERATION_HOURS_ON_FOOD_SPOTS_HISTORY FOREIGN KEY (food_spots_history_id) REFERENCES food_spots_histories (id);
 
+CREATE INDEX report_operation_hours_food_spots_history_id_index ON report_operation_hours (food_spots_history_id);
+
 CREATE SEQUENCE report_food_categories_seq START WITH 1 INCREMENT BY 1;
 
 CREATE TABLE report_food_categories
@@ -27,3 +29,7 @@ ALTER TABLE report_food_categories
 
 ALTER TABLE report_food_categories
     ADD CONSTRAINT FK_REPORT_FOOD_CATEGORIES_ON_FOOD_SPOTS_HISTORY FOREIGN KEY (food_spots_history_id) REFERENCES food_spots_histories (id);
+
+CREATE INDEX report_food_categories_food_categories_id_index ON report_food_categories (food_categories_id);
+
+CREATE INDEX report_food_categories_food_spots_history_id_index ON report_food_categories (food_spots_history_id);

--- a/src/main/resources/db/migration/V6__create_report_food_categories_and_operation_hours.sql
+++ b/src/main/resources/db/migration/V6__create_report_food_categories_and_operation_hours.sql
@@ -1,0 +1,29 @@
+CREATE TABLE report_operation_hours
+(
+    food_spots_history_id NUMBER(38, 0) NOT NULL,
+    created_datetime      TIMESTAMP     NOT NULL,
+    day_of_week           NUMBER(5)     NOT NULL,
+    opening_hours         VARCHAR2(5)   NOT NULL,
+    closing_hours         VARCHAR2(5)   NOT NULL,
+    CONSTRAINT pk_report_operation_hours PRIMARY KEY (food_spots_history_id, day_of_week)
+);
+
+ALTER TABLE report_operation_hours
+    ADD CONSTRAINT FK_REPORT_OPERATION_HOURS_ON_FOOD_SPOTS_HISTORY FOREIGN KEY (food_spots_history_id) REFERENCES food_spots_histories (id);
+
+CREATE SEQUENCE report_food_categories_seq START WITH 1 INCREMENT BY 1;
+
+CREATE TABLE report_food_categories
+(
+    id                    NUMBER(38, 0) NOT NULL,
+    created_datetime      TIMESTAMP     NOT NULL,
+    food_spots_history_id NUMBER(38, 0),
+    food_categories_id    NUMBER(38, 0),
+    CONSTRAINT pk_report_food_categories PRIMARY KEY (id)
+);
+
+ALTER TABLE report_food_categories
+    ADD CONSTRAINT FK_REPORT_FOOD_CATEGORIES_ON_FOOD_CATEGORIES FOREIGN KEY (food_categories_id) REFERENCES food_categories (id);
+
+ALTER TABLE report_food_categories
+    ADD CONSTRAINT FK_REPORT_FOOD_CATEGORIES_ON_FOOD_SPOTS_HISTORY FOREIGN KEY (food_spots_history_id) REFERENCES food_spots_histories (id);

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -2,8 +2,12 @@ package kr.weit.roadyfoody.foodSpots.fixture
 
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots.Companion.SRID_WGS84
+import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
+import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsOperationHours
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
+import kr.weit.roadyfoody.foodSpots.domain.ReportFoodCategory
+import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.dto.ReportHistoriesResponse
 import kr.weit.roadyfoody.foodSpots.dto.ReportPhotoResponse
 import kr.weit.roadyfoody.foodSpots.dto.ReportRequest
@@ -61,7 +65,9 @@ fun createTestFoodSpots(
     open: Boolean = TEST_FOOD_SPOT_OPEN,
     storeClosure: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
     point: Point = TEST_FOOD_SPOT_POINT,
-) = FoodSpots(id, name, foodTruck, open, storeClosure, point)
+    operationHours: MutableList<FoodSpotsOperationHours> = mutableListOf(),
+    category: MutableList<FoodSpotsFoodCategory> = mutableListOf(),
+) = FoodSpots(id, name, foodTruck, open, storeClosure, point, operationHours, category)
 
 fun createTestFoodHistory(
     id: Long = 0L,
@@ -72,7 +78,9 @@ fun createTestFoodHistory(
     open: Boolean = TEST_FOOD_SPOT_OPEN,
     storeClosure: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
     point: Point = TEST_FOOD_SPOT_POINT,
-) = FoodSpotsHistory(id, foodSpots, user, name, foodTruck, open, storeClosure, point)
+    operationHours: MutableList<ReportOperationHours> = mutableListOf(),
+    category: MutableList<ReportFoodCategory> = mutableListOf(),
+) = FoodSpotsHistory(id, foodSpots, user, name, foodTruck, open, storeClosure, point, operationHours, category)
 
 fun createTestFoodSpotsPhoto(foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory()) =
     FoodSpotsPhoto(0L, foodSpotsHistory, TEST_PHOTO_NAME)
@@ -122,7 +130,9 @@ class MockTestFoodSpot(
     open: Boolean = TEST_FOOD_SPOT_OPEN,
     closed: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
     point: Point = TEST_FOOD_SPOT_POINT,
-) : FoodSpots(id, name, foodTruck, open, closed, point) {
+    operationHoursList: MutableList<FoodSpotsOperationHours> = mutableListOf(),
+    categoryList: MutableList<FoodSpotsFoodCategory> = mutableListOf(),
+) : FoodSpots(id, name, foodTruck, open, closed, point, operationHoursList, categoryList) {
     override var createdDateTime: LocalDateTime = LocalDateTime.now()
     override var updatedDateTime: LocalDateTime = LocalDateTime.now()
 }
@@ -136,6 +146,8 @@ class MockTestFoodSpotsHistory(
     open: Boolean = TEST_FOOD_SPOT_OPEN,
     closed: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
     point: Point = TEST_FOOD_SPOT_POINT,
-) : FoodSpotsHistory(id, foodSpots, user, name, foodTruck, open, closed, point) {
+    operationHours: MutableList<ReportOperationHours> = mutableListOf(),
+    category: MutableList<ReportFoodCategory> = mutableListOf(),
+) : FoodSpotsHistory(id, foodSpots, user, name, foodTruck, open, closed, point, operationHours, category) {
     override var createdDateTime: LocalDateTime = LocalDateTime.now()
 }


### PR DESCRIPTION
### 개요

### 변경사항
- 에러코드 ApiResponse 커스텀 어노테이션으로 변경
- 표준 상호 규칙에 따른 허용 특수문자 변경
- 영업시간/카테고리 리스트 OneToMany 추가
- Report 운영시간/카테고리 엔티티 추가

### 테스트
- 테스트 코드 추가여부 X
비즈니스 코드 X

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-79) 


### 리뷰어에게 하고 싶은 말
엔티티 추가/변경에 대한 내용만 올리는 것이 좋을 거 같아 먼저 올립니다. 
FoodSpotsFixture과 ReportDtos은 mutableListOf()라고 되어있는데, 엔티티 추가/변경에 따른 다른 코드들 변경은 다음 작업으로 올리겠습니다. 엔티티에 관해서 중점적으로 봐주셨음 좋겠습니다 :)
<img width="814" alt="스크린샷 2024-07-07 오후 5 29 27" src="https://github.com/Weit-2nd/roady-foody-server/assets/113508969/c19651ab-ffda-4b83-b9f0-0723d08c7c67">
