### PR TITLE
ROFO-74 회원탈퇴 API 작성

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthEventHandler.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthEventHandler.kt
@@ -1,0 +1,29 @@
+package kr.weit.roadyfoody.auth.application.event
+
+import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
+import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.user.repository.UserRepository
+import kr.weit.roadyfoody.user.repository.getByUserId
+import kr.weit.roadyfoody.useragreedterm.repository.UserAgreedTermRepository
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class AuthEventHandler(
+    private val userRepository: UserRepository,
+    private val userAgreedTermRepository: UserAgreedTermRepository,
+    private val imageService: ImageService,
+    private val jwtUtil: JwtUtil,
+) {
+    @EventListener(AuthLeaveEvent::class)
+    fun handleAuthLeaveEvent(event: AuthLeaveEvent) {
+        val user = userRepository.getByUserId(event.userId)
+        userAgreedTermRepository.deleteAllByUser(user)
+        userRepository.delete(user)
+        val profileImageName = user.profile.profileImageName
+        profileImageName?.let {
+            imageService.remove(profileImageName)
+        }
+        jwtUtil.removeCachedRefreshToken(user.id)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthEventHandler.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthEventHandler.kt
@@ -15,6 +15,7 @@ class AuthEventHandler(
     private val imageService: ImageService,
     private val jwtUtil: JwtUtil,
 ) {
+    // TODO : 각 도메인 개발 상황에 따라 기능을 추가해주세요.
     @EventListener(AuthLeaveEvent::class)
     fun handleAuthLeaveEvent(event: AuthLeaveEvent) {
         val user = userRepository.getByUserId(event.userId)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthLeaveEvent.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/event/AuthLeaveEvent.kt
@@ -1,0 +1,5 @@
+package kr.weit.roadyfoody.auth.application.event
+
+class AuthLeaveEvent(
+    val userId: Long,
+)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
@@ -3,6 +3,7 @@ package kr.weit.roadyfoody.auth.application.service
 import kr.weit.roadyfoody.auth.application.dto.ServiceTokensResponse
 import kr.weit.roadyfoody.auth.application.dto.SignUpRequest
 import kr.weit.roadyfoody.auth.application.event.AuthLeaveEvent
+import kr.weit.roadyfoody.auth.exception.InvalidRefreshTokenException
 import kr.weit.roadyfoody.auth.exception.UserAlreadyExistsException
 import kr.weit.roadyfoody.auth.exception.UserNotRegisteredException
 import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
@@ -75,7 +76,7 @@ class AuthCommandService(
             jwtUtil.validateToken(jwtUtil.refreshKey, refreshToken) &&
                 jwtUtil.validateCachedRefreshTokenRotateId(refreshToken),
         ) {
-            "RefreshToken 이 유효하지 않습니다."
+            throw InvalidRefreshTokenException()
         }
         val userId = jwtUtil.getUserId(jwtUtil.refreshKey, refreshToken)
         val user = userRepository.getByUserId(userId)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
@@ -2,6 +2,7 @@ package kr.weit.roadyfoody.auth.application.service
 
 import kr.weit.roadyfoody.auth.application.dto.ServiceTokensResponse
 import kr.weit.roadyfoody.auth.application.dto.SignUpRequest
+import kr.weit.roadyfoody.auth.application.event.AuthLeaveEvent
 import kr.weit.roadyfoody.auth.exception.UserAlreadyExistsException
 import kr.weit.roadyfoody.auth.exception.UserNotRegisteredException
 import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
@@ -12,6 +13,7 @@ import kr.weit.roadyfoody.user.domain.User
 import kr.weit.roadyfoody.user.repository.UserRepository
 import kr.weit.roadyfoody.user.repository.getByUserId
 import kr.weit.roadyfoody.useragreedterm.application.service.UserAgreedTermCommandService
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -24,6 +26,7 @@ class AuthCommandService(
     private val userRepository: UserRepository,
     private val imageService: ImageService,
     private val jwtUtil: JwtUtil,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     @Transactional
     fun register(
@@ -89,5 +92,10 @@ class AuthCommandService(
 
     fun logout(user: User) {
         jwtUtil.removeCachedRefreshToken(user.id)
+    }
+
+    @Transactional
+    fun leave(user: User) {
+        applicationEventPublisher.publishEvent(AuthLeaveEvent(user.id))
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/exception/AuthExceptions.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/exception/AuthExceptions.kt
@@ -1,0 +1,40 @@
+package kr.weit.roadyfoody.auth.exception
+
+import kr.weit.roadyfoody.common.exception.BaseException
+import kr.weit.roadyfoody.common.exception.ErrorCode
+
+class InvalidTokenException : BaseException(
+    ErrorCode.INVALID_TOKEN,
+    ErrorCode.INVALID_TOKEN.errorMessage,
+)
+
+class UserAlreadyExistsException : BaseException(
+    ErrorCode.USER_ALREADY_EXISTS,
+    ErrorCode.USER_ALREADY_EXISTS.errorMessage,
+)
+
+class MissingSocialAccessTokenException() : BaseException(
+    ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN,
+    ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN.errorMessage,
+)
+
+class UserNotRegisteredException() : BaseException(
+    ErrorCode.USER_NOT_REGISTERED,
+    ErrorCode.USER_NOT_REGISTERED.errorMessage,
+)
+
+class MissingRefreshTokenException() : BaseException(
+    ErrorCode.MISSING_REFRESH_TOKEN,
+    ErrorCode.MISSING_REFRESH_TOKEN.errorMessage,
+)
+
+class InvalidRefreshTokenException() : BaseException(
+    ErrorCode.INVALID_REFRESH_TOKEN,
+    ErrorCode.INVALID_REFRESH_TOKEN.errorMessage,
+)
+
+class AuthenticatedUserNotFoundException() :
+    BaseException(
+        ErrorCode.AUTHENTICATED_USER_NOT_FOUND,
+        ErrorCode.AUTHENTICATED_USER_NOT_FOUND.errorMessage,
+    )

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/exception/InvalidTokenException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/exception/InvalidTokenException.kt
@@ -1,9 +1,0 @@
-package kr.weit.roadyfoody.auth.exception
-
-import kr.weit.roadyfoody.common.exception.BaseException
-import kr.weit.roadyfoody.common.exception.ErrorCode
-
-class InvalidTokenException : BaseException(
-    ErrorCode.UNAUTHORIZED,
-    "유효하지 않은 토큰입니다.",
-)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/exception/MissingSocialAccessTokenException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/exception/MissingSocialAccessTokenException.kt
@@ -1,9 +1,0 @@
-package kr.weit.roadyfoody.auth.exception
-
-import kr.weit.roadyfoody.common.exception.BaseException
-import kr.weit.roadyfoody.common.exception.ErrorCode
-
-class MissingSocialAccessTokenException() : BaseException(
-    ErrorCode.UNAUTHORIZED,
-    "SocialAccessToken 이 존재하지 않습니다.",
-)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/exception/UserAlreadyExistsException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/exception/UserAlreadyExistsException.kt
@@ -1,9 +1,0 @@
-package kr.weit.roadyfoody.auth.exception
-
-import kr.weit.roadyfoody.common.exception.BaseException
-import kr.weit.roadyfoody.common.exception.ErrorCode
-
-class UserAlreadyExistsException : BaseException(
-    ErrorCode.EXIST_RESOURCE,
-    "이미 존재하는 유저입니다.",
-)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/exception/UserNotRegisteredException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/exception/UserNotRegisteredException.kt
@@ -1,8 +1,0 @@
-package kr.weit.roadyfoody.auth.exception
-
-import kr.weit.roadyfoody.common.exception.BaseException
-import kr.weit.roadyfoody.common.exception.ErrorCode
-
-class UserNotRegisteredException(
-    message: String = "회원가입을 하지 않은 사용자입니다.",
-) : BaseException(ErrorCode.NOT_FOUND_USER, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthController.kt
@@ -76,4 +76,12 @@ class AuthController(
     ) {
         authCommandService.logout(user)
     }
+
+    @ResponseStatus(NO_CONTENT)
+    @PostMapping("/withdraw")
+    override fun withdraw(
+        @LoginUser user: User,
+    ) {
+        authCommandService.leave(user)
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthController.kt
@@ -6,6 +6,7 @@ import kr.weit.roadyfoody.auth.application.dto.ServiceTokensResponse
 import kr.weit.roadyfoody.auth.application.dto.SignUpRequest
 import kr.weit.roadyfoody.auth.application.service.AuthCommandService
 import kr.weit.roadyfoody.auth.application.service.AuthQueryService
+import kr.weit.roadyfoody.auth.exception.MissingRefreshTokenException
 import kr.weit.roadyfoody.auth.exception.MissingSocialAccessTokenException
 import kr.weit.roadyfoody.auth.presentation.spec.AuthControllerSpec
 import kr.weit.roadyfoody.auth.security.LoginUser
@@ -65,7 +66,7 @@ class AuthController(
     override fun refresh(
         @RequestParam("token") refreshToken: String?,
     ): ServiceTokensResponse {
-        requireNotNull(refreshToken) { "RefreshToken 이 존재하지 않습니다." }
+        requireNotNull(refreshToken) { throw MissingRefreshTokenException() }
         return authCommandService.reissueTokens(refreshToken)
     }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
@@ -348,4 +348,51 @@ interface AuthControllerSpec {
         @Parameter(hidden = true)
         user: User,
     )
+
+    @Operation(
+        summary = "회원탈퇴 API",
+        description = "Authorization 헤더에 AccessToken(Bearer)을 넣어 회원탈퇴를 진행합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "회원탈퇴 성공",
+            ),
+            ApiResponse(
+                responseCode = "401",
+                description = "유효하지 않은 토큰으로 요청",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Unauthenticated Access",
+                                summary = "인증되지 않은 접근",
+                                value = """
+                        {
+                            "code": -10001,
+                            "errorMessage": "인증정보가 없습니다."
+                        }
+                        """,
+                            ),
+                            ExampleObject(
+                                name = "Authenticated User Not Found",
+                                summary = "존재하지 않는 사용자",
+                                value = """
+                        {
+                            "code": -10001,
+                            "errorMessage": "인증된 사용자를 찾을 수 없습니다."
+                        }
+                        """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun withdraw(
+        @Parameter(hidden = true)
+        user: User,
+    )
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
@@ -12,12 +12,23 @@ import jakarta.validation.Valid
 import kr.weit.roadyfoody.auth.application.dto.DuplicatedNicknameResponse
 import kr.weit.roadyfoody.auth.application.dto.ServiceTokensResponse
 import kr.weit.roadyfoody.auth.application.dto.SignUpRequest
+import kr.weit.roadyfoody.common.exception.ErrorCode.AUTHENTICATED_USER_NOT_FOUND
+import kr.weit.roadyfoody.common.exception.ErrorCode.INVALID_NICKNAME
+import kr.weit.roadyfoody.common.exception.ErrorCode.INVALID_REFRESH_TOKEN
+import kr.weit.roadyfoody.common.exception.ErrorCode.INVALID_TOKEN
+import kr.weit.roadyfoody.common.exception.ErrorCode.INVALID_WEBP_IMAGE
+import kr.weit.roadyfoody.common.exception.ErrorCode.MAX_FILE_SIZE_EXCEEDED
+import kr.weit.roadyfoody.common.exception.ErrorCode.MISSING_REFRESH_TOKEN
+import kr.weit.roadyfoody.common.exception.ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN
+import kr.weit.roadyfoody.common.exception.ErrorCode.UNAUTHENTICATED_ACCESS
+import kr.weit.roadyfoody.common.exception.ErrorCode.USER_ALREADY_EXISTS
+import kr.weit.roadyfoody.common.exception.ErrorCode.USER_NOT_REGISTERED
 import kr.weit.roadyfoody.common.exception.ErrorResponse
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 import kr.weit.roadyfoody.global.validator.MaxFileSize
 import kr.weit.roadyfoody.global.validator.WebPImage
 import kr.weit.roadyfoody.user.domain.User
-import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX_DESC
 import kr.weit.roadyfoody.useragreedterm.exception.ERROR_MSG_PREFIX
 import kr.weit.roadyfoody.useragreedterm.exception.ERROR_MSG_SUFFIX
 import org.springframework.http.MediaType
@@ -35,78 +46,18 @@ interface AuthControllerSpec {
             ),
             ApiResponse(
                 responseCode = "400",
-                description = "회원가입 실패",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "Invalid Image Input",
-                                summary = "WEBP 이외의 이미지 입력",
+                                name = "Not Enough Required Term IDs",
+                                summary = "NOT_ENOUGH_REQUIRED_TERM_IDS",
                                 value = """
                         {
                             "code": -10000,
-                            "errorMessage": "profileImage: webp 형식이 아닙니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Max Size Exceeded",
-                                summary = "최대 사진 크기 초과",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "파일 사이즈가 초과하였습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid Nickname Input",
-                                summary = "미충족 닉네임 입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "$NICKNAME_REGEX_DESC"
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Not Enough Required TermIds",
-                                summary = "필수약관 미동의",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "$ERROR_MSG_PREFIX $ERROR_MSG_SUFFIX"
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ), ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 토큰으로 요청",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Missing Social Access Token",
-                                summary = "SocialAccessToken 미입력",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "SocialAccessToken 이 존재하지 않습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "유효하지 않은 토큰입니다."
+                            "errorMessage": "$ERROR_MSG_PREFIX 1, 2 $ERROR_MSG_SUFFIX"
                         }
                         """,
                             ),
@@ -114,26 +65,16 @@ interface AuthControllerSpec {
                     ),
                 ],
             ),
-            ApiResponse(
-                responseCode = "409",
-                description = "중복된 회원가입 요청",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                value = """
-                        {
-                            "code": -10005,
-                            "errorMessage": "이미 존재하는 유저입니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            INVALID_WEBP_IMAGE,
+            MAX_FILE_SIZE_EXCEEDED,
+            INVALID_NICKNAME,
+            MISSING_SOCIAL_ACCESS_TOKEN,
+            INVALID_TOKEN,
+            USER_ALREADY_EXISTS,
         ],
     )
     fun signUp(
@@ -161,21 +102,6 @@ interface AuthControllerSpec {
             ApiResponse(
                 responseCode = "200",
                 description = "요청 성공",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = DuplicatedNicknameResponse::class),
-                        examples = [
-                            ExampleObject(
-                                value = """
-                        {
-                            "isDuplicated": true
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
             ),
         ],
     )
@@ -189,60 +115,13 @@ interface AuthControllerSpec {
                 responseCode = "200",
                 description = "로그인 성공",
             ),
-            ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 토큰으로 요청",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Missing Social Access Token",
-                                summary = "SocialAccessToken 미입력",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "SocialAccessToken 이 존재하지 않습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid Social Access Token",
-                                summary = "유효하지 않는 SocialAccessToken",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "유효하지 않은 토큰입니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "유저 정보 없음",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Not Registered User",
-                                summary = "미가입 유저",
-                                value = """
-                        {
-                            "code": -10009,
-                            "errorMessage": "회원가입을 하지 않은 사용자입니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            MISSING_SOCIAL_ACCESS_TOKEN,
+            INVALID_TOKEN,
+            USER_NOT_REGISTERED,
         ],
     )
     fun signIn(
@@ -258,38 +137,12 @@ interface AuthControllerSpec {
                 responseCode = "200",
                 description = "요청 성공",
             ),
-            ApiResponse(
-                responseCode = "400",
-                description = "요청 실패",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Missing Refresh Token",
-                                summary = "RefreshToken 미입력",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "RefreshToken 이 존재하지 않습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Invalid Refresh Token",
-                                summary = "유효하지 않은 RefreshToken",
-                                value = """
-                        {
-                            "code": -10000,
-                            "errorMessage": "RefreshToken 이 유효하지 않습니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            MISSING_REFRESH_TOKEN,
+            INVALID_REFRESH_TOKEN,
         ],
     )
     fun refresh(
@@ -310,38 +163,12 @@ interface AuthControllerSpec {
                 responseCode = "204",
                 description = "로그아웃 성공",
             ),
-            ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 토큰으로 요청",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Unauthenticated Access",
-                                summary = "인증되지 않은 접근",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "인증정보가 없습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Authenticated User Not Found",
-                                summary = "존재하지 않는 사용자",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "인증된 사용자를 찾을 수 없습니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            UNAUTHENTICATED_ACCESS,
+            AUTHENTICATED_USER_NOT_FOUND,
         ],
     )
     fun signOut(user: User)
@@ -354,38 +181,12 @@ interface AuthControllerSpec {
                 responseCode = "204",
                 description = "회원탈퇴 성공",
             ),
-            ApiResponse(
-                responseCode = "401",
-                description = "유효하지 않은 토큰으로 요청",
-                content = [
-                    Content(
-                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Unauthenticated Access",
-                                summary = "인증되지 않은 접근",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "인증정보가 없습니다."
-                        }
-                        """,
-                            ),
-                            ExampleObject(
-                                name = "Authenticated User Not Found",
-                                summary = "존재하지 않는 사용자",
-                                value = """
-                        {
-                            "code": -10001,
-                            "errorMessage": "인증된 사용자를 찾을 수 없습니다."
-                        }
-                        """,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            UNAUTHENTICATED_ACCESS,
+            AUTHENTICATED_USER_NOT_FOUND,
         ],
     )
     fun withdraw(user: User)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/presentation/spec/AuthControllerSpec.kt
@@ -344,10 +344,7 @@ interface AuthControllerSpec {
             ),
         ],
     )
-    fun signOut(
-        @Parameter(hidden = true)
-        user: User,
-    )
+    fun signOut(user: User)
 
     @Operation(
         summary = "회원탈퇴 API",
@@ -391,8 +388,5 @@ interface AuthControllerSpec {
             ),
         ],
     )
-    fun withdraw(
-        @Parameter(hidden = true)
-        user: User,
-    )
+    fun withdraw(user: User)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/security/LoginUserResolver.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/security/LoginUserResolver.kt
@@ -1,7 +1,6 @@
 package kr.weit.roadyfoody.auth.security
 
-import kr.weit.roadyfoody.common.exception.BaseException
-import kr.weit.roadyfoody.common.exception.ErrorCode
+import kr.weit.roadyfoody.auth.exception.AuthenticatedUserNotFoundException
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.core.MethodParameter
 import org.springframework.security.core.context.SecurityContextHolder
@@ -26,6 +25,3 @@ class LoginUserResolver : HandlerMethodArgumentResolver {
         return (authentication as? SecurityUser)?.user ?: throw AuthenticatedUserNotFoundException()
     }
 }
-
-class AuthenticatedUserNotFoundException(message: String = "인증된 사용자를 찾을 수 없습니다.") :
-    BaseException(ErrorCode.UNAUTHORIZED, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/security/config/SecurityConfig.kt
@@ -54,4 +54,8 @@ val PERMITTED_URL_PATTERNS =
         "/api/v1/food-spots/**",
     )
 
-val NOT_PERMITTED_URL_PATTERNS = arrayOf("/api/v1/auth/sign-out")
+val NOT_PERMITTED_URL_PATTERNS =
+    arrayOf(
+        "/api/v1/auth/sign-out",
+        "/api/v1/auth/withdraw",
+    )

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/security/handler/CustomAuthenticationEntryPoint.kt
@@ -22,7 +22,10 @@ class CustomAuthenticationEntryPoint(
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         objectMapper.writeValue(
             response?.outputStream,
-            ErrorResponse.of(ErrorCode.UNAUTHORIZED, "인증정보가 없습니다."),
+            ErrorResponse.of(
+                ErrorCode.UNAUTHENTICATED_ACCESS,
+                ErrorCode.UNAUTHENTICATED_ACCESS.errorMessage,
+            ),
         )
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.common.exception
 
+import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX_DESC
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage: String) {
@@ -16,9 +17,22 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
 
     // Bad Request -10000으로 코드 통일
     SIZE_NON_POSITIVE(HttpStatus.BAD_REQUEST, -10000, "조회할 개수는 양수여야 합니다."),
+    INVALID_WEBP_IMAGE(HttpStatus.BAD_REQUEST, -10000, "webp 형식이 아닙니다."),
+    MAX_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, -10000, "파일 사이즈가 초과하였습니다."),
 
     // Search API error 11000대
     REST_CLIENT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -11000, "외부 API 호출 중 에러 발생"),
     RETRIES_EXCEEDED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -11001, "외부 API 호출 재시도 횟수 초과"),
     SEARCH_KEYWORD_LENGTH(HttpStatus.BAD_REQUEST, -10000, "검색어는 2자 이상 60자 이하로 입력해주세요."),
+
+    // Auth API error 12000대
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, -12000, "유효하지 않은 토큰입니다."),
+    MISSING_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -12001, "SocialAccessToken 이 존재하지 않습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, -12002, "이미 존재하는 유저입니다."),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, -10000, NICKNAME_REGEX_DESC),
+    USER_NOT_REGISTERED(HttpStatus.NOT_FOUND, -12003, "회원가입을 하지 않은 사용자입니다."),
+    MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, -10000, "RefreshToken 이 존재하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, -10000, "유효하지 않은 RefreshToken 입니다."),
+    UNAUTHENTICATED_ACCESS(HttpStatus.UNAUTHORIZED, -12004, "인증정보가 없습니다."),
+    AUTHENTICATED_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, -12005, "인증된 사용자를 찾을 수 없습니다."),
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/global/service/ImageService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/service/ImageService.kt
@@ -22,4 +22,8 @@ class ImageService(
         val extension = MimeUtils.getFileExtension(file)
         return "${UUID.randomUUID()}$extension"
     }
+
+    fun remove(name: String) {
+        storageService.delete(name)
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
@@ -11,12 +11,14 @@ import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.ErrorResponse
 import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExample
 import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.ExampleHolder
 import org.springdoc.core.customizers.OperationCustomizer
+import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.AUTHORIZATION
@@ -24,6 +26,10 @@ import org.springframework.web.method.HandlerMethod
 
 @Configuration
 class ApiDocsConfig {
+    init {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser::class.java)
+    }
+
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
@@ -69,8 +75,6 @@ class ApiDocsConfig {
             apiErrorCodeExample?.run {
                 generateErrorCodeResponseExample(operation, apiErrorCodeExample.value)
             }
-
-            hideParameterByType(operation, "User")
 
             operation
         }
@@ -147,15 +151,5 @@ class ApiDocsConfig {
         content.addMediaType("application/json", mediaType)
         apiResponse.content = content
         responses.addApiResponse(exampleHolder.code.toString(), apiResponse)
-    }
-
-    private fun hideParameterByType(
-        operation: Operation,
-        parameterType: String,
-    ) {
-        operation.parameters =
-            operation.parameters?.filterNot { parameter ->
-                parameter.schema?.`$ref`?.endsWith("/$parameterType") == true
-            }
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
@@ -122,9 +122,9 @@ class ApiDocsConfig {
         statusWithExampleHolders: Map<Int, List<ExampleHolder>>,
     ) {
         statusWithExampleHolders.forEach { (status, v) ->
-            val content = Content()
-            val mediaType = MediaType()
-            val apiResponse = ApiResponse()
+            val apiResponse = responses.getOrDefault(status.toString(), ApiResponse())
+            val content = apiResponse.content ?: Content()
+            val mediaType = content.getOrDefault("application/json", MediaType())
 
             v.forEach { exampleHolder ->
                 mediaType.addExamples(exampleHolder.name, exampleHolder.holder)
@@ -139,9 +139,9 @@ class ApiDocsConfig {
         responses: ApiResponses,
         exampleHolder: ExampleHolder,
     ) {
-        val content = Content()
-        val mediaType = MediaType()
-        val apiResponse = ApiResponse()
+        val apiResponse = responses.getOrDefault(exampleHolder.code.toString(), ApiResponse())
+        val content = apiResponse.content ?: Content()
+        val mediaType = content.getOrDefault("application/json", MediaType())
 
         mediaType.addExamples(exampleHolder.name, exampleHolder.holder)
         content.addMediaType("application/json", mediaType)

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/config/ApiDocsConfig.kt
@@ -70,6 +70,8 @@ class ApiDocsConfig {
                 generateErrorCodeResponseExample(operation, apiErrorCodeExample.value)
             }
 
+            hideParameterByType(operation, "User")
+
             operation
         }
     }
@@ -145,5 +147,15 @@ class ApiDocsConfig {
         content.addMediaType("application/json", mediaType)
         apiResponse.content = content
         responses.addApiResponse(exampleHolder.code.toString(), apiResponse)
+    }
+
+    private fun hideParameterByType(
+        operation: Operation,
+        parameterType: String,
+    ) {
+        operation.parameters =
+            operation.parameters?.filterNot { parameter ->
+                parameter.schema?.`$ref`?.endsWith("/$parameterType") == true
+            }
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/term/presentation/spec/TermControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/term/presentation/spec/TermControllerSpec.kt
@@ -37,16 +37,15 @@ interface TermControllerSpec {
                         schema = Schema(implementation = DetailedTermResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "약관 상세 정보 반환 성공",
                                 summary = "약관 상세 정보 반환 성공",
                                 value = """
-                            {
-                                "id": 1,
-                                "title": "약관 제목",
-                                "isRequired": true,
-                                "content": "<html>약관 내용</html>"
-                            }
-                            """,
+                        {
+                            "id": 1,
+                            "title": "약관 제목",
+                            "isRequired": true,
+                            "content": "<html>약관 내용</html>"
+                        }
+                        """,
                             ),
                         ],
                     ),
@@ -54,15 +53,14 @@ interface TermControllerSpec {
             ),
             ApiResponse(
                 responseCode = "404",
-                description = "약관 상세 정보 반환 실패",
                 content = [
                     Content(
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
                         schema = Schema(implementation = ErrorResponse::class),
                         examples = [
                             ExampleObject(
-                                name = "약관 상세 정보 반환 실패",
-                                summary = "약관 상세 정보 반환 실패",
+                                name = "Term Not Found",
+                                summary = "TERM_NOT_FOUND",
                                 value = """
                         {
                             "code": -10010,

--- a/src/main/kotlin/kr/weit/roadyfoody/useragreedterm/repository/UserAgreedTermRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/useragreedterm/repository/UserAgreedTermRepository.kt
@@ -1,6 +1,9 @@
 package kr.weit.roadyfoody.useragreedterm.repository
 
+import kr.weit.roadyfoody.user.domain.User
 import kr.weit.roadyfoody.useragreedterm.domain.UserAgreedTerm
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserAgreedTermRepository : JpaRepository<UserAgreedTerm, Long>
+interface UserAgreedTermRepository : JpaRepository<UserAgreedTerm, Long> {
+    fun deleteAllByUser(user: User)
+}

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
+import kr.weit.roadyfoody.auth.exception.InvalidRefreshTokenException
 import kr.weit.roadyfoody.auth.exception.UserAlreadyExistsException
 import kr.weit.roadyfoody.auth.exception.UserNotRegisteredException
 import kr.weit.roadyfoody.auth.fixture.TEST_ACCESS_TOKEN
@@ -261,8 +262,8 @@ class AuthCommandServiceTest : BehaviorSpec({
 
         `when`("유효하지 않은 refreshToken 이면") {
             every { jwtUtil.validateToken(any<SecretKey>(), any<String>()) } returns false
-            then("IllegalArgumentException 예외가 발생한다.") {
-                shouldThrow<IllegalArgumentException> {
+            then("InvalidRefreshTokenException 예외가 발생한다.") {
+                shouldThrow<InvalidRefreshTokenException> {
                     authCommandService.reissueTokens(TEST_BEARER_ACCESS_TOKEN)
                 }
                 verify(exactly = 1) {
@@ -275,8 +276,8 @@ class AuthCommandServiceTest : BehaviorSpec({
         `when`("일치하지 않은 refreshTokenRotateId 이면") {
             every { jwtUtil.validateToken(any<SecretKey>(), any<String>()) } returns true
             every { jwtUtil.validateCachedRefreshTokenRotateId(any<String>()) } returns false
-            then("IllegalArgumentException 예외가 발생한다.") {
-                shouldThrow<IllegalArgumentException> {
+            then("InvalidRefreshTokenException 예외가 발생한다.") {
+                shouldThrow<InvalidRefreshTokenException> {
                     authCommandService.reissueTokens(TEST_REFRESH_TOKEN)
                 }
                 verify(exactly = 1) {

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandServiceTest.kt
@@ -29,6 +29,7 @@ import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository
 import kr.weit.roadyfoody.useragreedterm.application.service.UserAgreedTermCommandService
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.web.multipart.MultipartFile
 import java.util.Optional
 import javax.crypto.SecretKey
@@ -40,8 +41,17 @@ class AuthCommandServiceTest : BehaviorSpec({
     val userRepository = mockk<UserRepository>()
     val imageService = spyk<ImageService>(ImageService(mockk()))
     val jwtUtil = mockk<JwtUtil>()
+    val applicationEventPublisher = mockk<ApplicationEventPublisher>()
     val authCommandService =
-        AuthCommandService(authQueryService, termCommandService, userAgreedTermCommandService, userRepository, imageService, jwtUtil)
+        AuthCommandService(
+            authQueryService,
+            termCommandService,
+            userAgreedTermCommandService,
+            userRepository,
+            imageService,
+            jwtUtil,
+            applicationEventPublisher,
+        )
 
     afterEach { clearAllMocks() }
 

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthIntegrationServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/application/service/AuthIntegrationServiceTest.kt
@@ -12,6 +12,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.verify
 import kr.weit.roadyfoody.auth.application.dto.ServiceTokensResponse
+import kr.weit.roadyfoody.auth.exception.InvalidRefreshTokenException
 import kr.weit.roadyfoody.auth.exception.UserAlreadyExistsException
 import kr.weit.roadyfoody.auth.fixture.TEST_SOCIAL_ACCESS_TOKEN
 import kr.weit.roadyfoody.auth.fixture.createTestKakaoUserResponse
@@ -167,9 +168,9 @@ class AuthIntegrationServiceTest(
             }
 
             `when`("캐시된 RotateId 가 소멸한 뒤 RefreshToken 을 전달하면") {
-                then("IllegalArgumentException 을 던진다") {
+                then("InvalidRefreshTokenException 을 던진다") {
                     redisTemplate.delete(getRefreshTokenCacheKey(user.id))
-                    shouldThrow<IllegalArgumentException> {
+                    shouldThrow<InvalidRefreshTokenException> {
                         authCommandService.reissueTokens(tokensResponse.refreshToken)
                     }
                     val isStored = redisTemplate.hasKey(getRefreshTokenCacheKey(user.id))
@@ -179,10 +180,10 @@ class AuthIntegrationServiceTest(
             }
 
             `when`("이미 한 번 사용된 refreshToken 을 전달하면") {
-                then("IllegalArgumentException 을 던진다") {
+                then("InvalidRefreshTokenException 을 던진다") {
                     val prevReissuedTokensResponse = authCommandService.reissueTokens(tokensResponse.refreshToken)
                     authCommandService.reissueTokens(prevReissuedTokensResponse.refreshToken)
-                    shouldThrow<IllegalArgumentException> {
+                    shouldThrow<InvalidRefreshTokenException> {
                         authCommandService.reissueTokens(prevReissuedTokensResponse.refreshToken)
                     }
                     verify(exactly = 2) { authQueryService.requestKakaoUserInfo(any<String>()) }

--- a/src/test/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/auth/presentation/api/AuthControllerTest.kt
@@ -282,4 +282,26 @@ class AuthControllerTest(
                 }
             }
         }
+
+        given("POST $requestPath/withdraw") {
+            `when`("로그인 사용자 정보를 전달하면") {
+                every { authCommandService.leave(any()) } just runs
+                then("탈퇴에 성공하고 204 상태번호를 반환한다") {
+                    mockMvc.perform(
+                        postWithAuth("$requestPath/withdraw"),
+                    ).andExpect(status().isNoContent)
+                    verify(exactly = 1) { authCommandService.leave(any()) }
+                }
+            }
+
+            `when`("로그인 사용자 정보가 없으면") {
+                every { authCommandService.leave(any()) } just runs
+                then("401 상태번호를 반환한다") {
+                    mockMvc.perform(
+                        post("$requestPath/withdraw"),
+                    ).andExpect(status().isUnauthorized)
+                    verify(exactly = 0) { authCommandService.leave(any()) }
+                }
+            }
+        }
     })

--- a/src/test/kotlin/kr/weit/roadyfoody/global/service/ImageServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/global/service/ImageServiceTest.kt
@@ -4,7 +4,9 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.inspectors.shouldForAny
 import io.kotest.matchers.string.shouldEndWith
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import kr.weit.roadyfoody.support.utils.ImageFormat.GIF
 import kr.weit.roadyfoody.support.utils.ImageFormat.JPEG
@@ -18,7 +20,7 @@ class ImageServiceTest : BehaviorSpec({
     val storageService = mockk<StorageService>()
     val imageService = ImageService(storageService)
 
-    given("upload 메소드") {
+    given("upload 테스트") {
         `when`("이미지를 업로드 하면") {
             every { storageService.upload(TEST_USER_PROFILE_IMAGE_NAME, any<InputStream>()) } returns ""
             then("이미지가 저장된다.") {
@@ -28,7 +30,7 @@ class ImageServiceTest : BehaviorSpec({
         }
     }
 
-    given("generateImageName 메소드") {
+    given("generateImageName 테스트") {
         `when`("WEBP 이미지 파일을 전달하면") {
             then("WEBP 확장자가 있는 이름이 생성된다.") {
                 val imageName = imageService.generateImageName(createTestImageFile(WEBP))
@@ -54,6 +56,16 @@ class ImageServiceTest : BehaviorSpec({
             then("GIF 확장자가 있는 이름이 생성된다.") {
                 val imageName = imageService.generateImageName(createTestImageFile(GIF))
                 GIF.values.shouldForAny { imageName.shouldEndWith(".$it") }
+            }
+        }
+    }
+
+    given("remove 테스트") {
+        `when`("이미지를 제거하면") {
+            every { storageService.delete(TEST_USER_PROFILE_IMAGE_NAME) } just runs
+            then("이미지가 삭제된다.") {
+                imageService.remove(TEST_USER_PROFILE_IMAGE_NAME)
+                verify(exactly = 1) { storageService.delete(TEST_USER_PROFILE_IMAGE_NAME) }
             }
         }
     }

--- a/src/test/kotlin/kr/weit/roadyfoody/useragreedterm/repository/UserAgreedTermRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/useragreedterm/repository/UserAgreedTermRepositoryTest.kt
@@ -1,0 +1,45 @@
+package kr.weit.roadyfoody.useragreedterm.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import kr.weit.roadyfoody.support.annotation.RepositoryTest
+import kr.weit.roadyfoody.term.domain.Term
+import kr.weit.roadyfoody.term.fixture.createTestTerms
+import kr.weit.roadyfoody.term.repository.TermRepository
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.fixture.createTestUser
+import kr.weit.roadyfoody.user.repository.UserRepository
+import kr.weit.roadyfoody.useragreedterm.domain.UserAgreedTerm
+
+@RepositoryTest
+class UserAgreedTermRepositoryTest(
+    private val userRepository: UserRepository,
+    private val termRepository: TermRepository,
+    private val userAgreedTermRepository: UserAgreedTermRepository,
+) : DescribeSpec({
+        lateinit var user: User
+        lateinit var terms: List<Term>
+
+        beforeEach {
+            user = userRepository.save(createTestUser())
+            terms = termRepository.saveAll(createTestTerms())
+            userAgreedTermRepository.saveAll(
+                terms.map { term ->
+                    UserAgreedTerm(
+                        user = user,
+                        term = term,
+                    )
+                },
+            )
+        }
+
+        describe("deleteAllByUser 메소드는") {
+            context("존재하는 user 를 받는 경우") {
+                it("해당 user 와 관련된 UserAgreedTerm 을 모두 삭제한다.") {
+                    userAgreedTermRepository.deleteAllByUser(user)
+                    val actual = userAgreedTermRepository.findAll()
+                    actual.shouldBeEmpty()
+                }
+            }
+        }
+    })


### PR DESCRIPTION
### 개요
회원탈퇴 기능을 작성합니다.
제거 범위는 유저동의약관과 유저, S3 이미지, redis refresh rotate Id 입니다.

### 변경사항
- ImageService remove 메소드 및 테스트 작성
- 유저동의약관 제거 쿼리 메소드 및 테스트 작성 (deleteAllByUser)
- AuthEventHandler 및 AuthLeaveEvent 객체 작성
- 회원탈퇴 API 및 테스트 작성

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-74) 


### 리뷰어에게 하고 싶은 말
이벤트 방식으로 구현되어 서비스단 테스트는 통합테스트로만 작성해봤습니다.
이벤트 방식으로 구현은 나름 해봤는데 이런식으로 하는게 맞는지 잘 모르겠네요..
회원탈퇴에 관련한 의존을 Handler 에서 맡은건 좋아보이지만 좀 어설픈것 같아 피드백을 듣고싶습니다.


스웨거 API 에러 부분을 어노테이션으로 대체해볼까 했지만 제가 반환하는 예외 중엔 
동적으로 예외메시지를 만드는 경우가 있어 모든 경우를 어노테이션으로 대체하기는 불가능해 보였습니다.
로컬 브랜치에 작업은 해뒀는데 저만의 기준이 세워지면 따로 PR 을 올리겠습니다. 