### PR TITLE
ROFO-105 백도어 관련 API 작성 (개발환경 토큰생성 편의)

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
@@ -1,0 +1,23 @@
+package kr.weit.roadyfoody.admin.application.service
+
+import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
+import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
+import kr.weit.roadyfoody.user.repository.UserRepository
+import kr.weit.roadyfoody.user.repository.getByUserId
+import org.springframework.stereotype.Service
+
+@Service
+class AdminCommandService(
+    private val userRepository: UserRepository,
+    private val jwtUtil: JwtUtil,
+) {
+    companion object {
+        private const val USER_ACCESS_TOKEN_EXPIRE_TIME = 1_000_000_000L
+    }
+
+    fun getUserAccessToken(userId: Long): UserAccessTokenResponse {
+        val user = userRepository.getByUserId(userId)
+        val accessToken = jwtUtil.generateAccessToken(user.id, USER_ACCESS_TOKEN_EXPIRE_TIME)
+        return UserAccessTokenResponse(accessToken)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryService.kt
@@ -1,0 +1,19 @@
+package kr.weit.roadyfoody.admin.application.service
+
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponse
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
+import kr.weit.roadyfoody.user.repository.UserRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+
+@Service
+class AdminQueryService(
+    private val userRepository: UserRepository,
+) {
+    fun getUserInfoList(pageable: Pageable): SimpleUserInfoResponses {
+        val users = userRepository.findAll(pageable).content
+        return SimpleUserInfoResponses(
+            users.map(SimpleUserInfoResponse::from),
+        )
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/dto/AdminDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/dto/AdminDtos.kt
@@ -1,0 +1,27 @@
+package kr.weit.roadyfoody.admin.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.weit.roadyfoody.user.domain.User
+
+data class SimpleUserInfoResponse(
+    @Schema(description = "유저 아이디", example = "1")
+    val userId: Long,
+    @Schema(description = "유저 닉네임", example = "유저1")
+    val nickname: String,
+    @Schema(description = "유저 코인 보유량", example = "100")
+    val coin: Int,
+) {
+    companion object {
+        fun from(user: User) = SimpleUserInfoResponse(user.id, user.profile.nickname, user.coin)
+    }
+}
+
+data class SimpleUserInfoResponses(
+    @Schema(description = "유저 정보")
+    val userInfo: List<SimpleUserInfoResponse>,
+)
+
+data class UserAccessTokenResponse(
+    @Schema(description = "유저 AccessToken")
+    val accessToken: String,
+)

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminController.kt
@@ -1,0 +1,32 @@
+package kr.weit.roadyfoody.admin.presentation.api
+
+import kr.weit.roadyfoody.admin.application.service.AdminCommandService
+import kr.weit.roadyfoody.admin.application.service.AdminQueryService
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
+import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
+import kr.weit.roadyfoody.admin.presentation.spec.AdminControllerSpec
+import org.springframework.context.annotation.Profile
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile("!stable")
+@RestController
+@RequestMapping("/api/v1/admin")
+class AdminController(
+    private val adminCommandService: AdminCommandService,
+    private val adminQueryService: AdminQueryService,
+) : AdminControllerSpec {
+    @GetMapping("/users")
+    override fun getUserInfoList(
+        @PageableDefault pageable: Pageable,
+    ): SimpleUserInfoResponses = adminQueryService.getUserInfoList(pageable)
+
+    @GetMapping("/users/{userId}/token")
+    override fun getUserAccessToken(
+        @PathVariable userId: Long,
+    ): UserAccessTokenResponse = adminCommandService.getUserAccessToken(userId)
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/spec/AdminControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/spec/AdminControllerSpec.kt
@@ -1,0 +1,95 @@
+package kr.weit.roadyfoody.admin.presentation.spec
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
+import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
+import kr.weit.roadyfoody.common.exception.ErrorResponse
+import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
+import org.springframework.data.domain.Pageable
+import org.springframework.http.MediaType
+
+@Tag(name = SwaggerTag.ADMIN)
+interface AdminControllerSpec {
+    @Operation(
+        summary = "유저 정보 조회",
+        description = "유저 정보를 조회합니다.",
+        parameters = [
+            Parameter(
+                name = "page",
+                description = "페이지 정보",
+                `in` = ParameterIn.QUERY,
+                required = true,
+                schema =
+                    Schema(
+                        type = "integer",
+                        example = "0",
+                    ),
+            ),
+            Parameter(
+                name = "size",
+                description = "페이지 사이즈",
+                `in` = ParameterIn.QUERY,
+                required = true,
+                schema =
+                    Schema(
+                        type = "integer",
+                        example = "10",
+                    ),
+            ),
+        ],
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "유저 정보 조회 성공",
+            ),
+        ],
+    )
+    fun getUserInfoList(
+        @Parameter(hidden = true)
+        pageable: Pageable,
+    ): SimpleUserInfoResponses
+
+    @Operation(
+        summary = "유저 AccessToken 조회",
+        description = "유저 AccessToken 을 조회합니다. (유효기간 10일 이상)",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "유저 AccessToken 조회 성공",
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리포트 리스트 조회 실패",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Not found user",
+                                summary = "NOT_FOUND_USER",
+                                value = """
+                                {
+                                    "code": -10009,
+                                    "errorMessage": "10 ID 의 사용자는 존재하지 않습니다."
+                                }
+                            """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getUserAccessToken(
+        @Parameter(description = "유저 아이디", required = true, example = "1")
+        userId: Long,
+    ): UserAccessTokenResponse
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/auth/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/security/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ val PERMITTED_URL_PATTERNS =
         "/actuator/prometheus",
         "/api/v1/terms/**",
         "/api/v1/auth/**",
+        "/api/v1/admin/**",
     )
 
 val NOT_PERMITTED_URL_PATTERNS =

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
@@ -7,4 +7,5 @@ object SwaggerTag {
     const val SEARCH: String = "C. 검색 API"
     const val FOOD_SPOTS: String = "D. 음식점 리포트 API"
     const val REVIEW: String = "E. 리뷰 API"
+    const val ADMIN: String = "Z. 관리자 API"
 }

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
@@ -1,0 +1,30 @@
+package kr.weit.roadyfoody.admin.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.weit.roadyfoody.auth.fixture.TEST_ACCESS_TOKEN
+import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
+import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
+import kr.weit.roadyfoody.user.fixture.createTestUser
+import kr.weit.roadyfoody.user.repository.UserRepository
+import java.util.Optional
+
+class AdminCommandServiceTest :
+    BehaviorSpec({
+        val userRepository = mockk<UserRepository>()
+        val jwtUtil = mockk<JwtUtil>()
+        val adminCommandService = AdminCommandService(userRepository, jwtUtil)
+
+        given("getUserAccessToken 테스트") {
+            `when`("유저 ID 로 요청하면") {
+                every { userRepository.findById(any()) } returns Optional.of(createTestUser())
+                every { jwtUtil.generateAccessToken(any(), any()) } returns TEST_ACCESS_TOKEN
+                then("UserAccessTokenResponse 를 반환한다.") {
+                    val actual = adminCommandService.getUserAccessToken(TEST_USER_ID).accessToken
+                    actual shouldBe TEST_ACCESS_TOKEN
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryServiceTest.kt
@@ -1,0 +1,29 @@
+package kr.weit.roadyfoody.admin.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.mockk.every
+import io.mockk.mockk
+import kr.weit.roadyfoody.user.fixture.createTestUsers
+import kr.weit.roadyfoody.user.repository.UserRepository
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+
+class AdminQueryServiceTest :
+    BehaviorSpec({
+        val userRepository = mockk<UserRepository>()
+        val adminQueryService = AdminQueryService(userRepository)
+
+        given("getUserInfoList 테스트") {
+            val users = createTestUsers()
+            val pageable = PageRequest.of(0, 10)
+            `when`("유저 정보를 조회하면") {
+                every { userRepository.findAll(any<Pageable>()) } returns PageImpl(users, pageable, 0)
+                then("SimpleUserInfoResponses 를 반환한다.") {
+                    val actual = adminQueryService.getUserInfoList(pageable).userInfo
+                    actual.shouldHaveSize(users.size)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/fixture/AdminDtoFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/fixture/AdminDtoFixture.kt
@@ -1,0 +1,14 @@
+package kr.weit.roadyfoody.admin.fixture
+
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponse
+import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
+import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
+import kr.weit.roadyfoody.user.fixture.createTestUser
+
+fun createTestSimpleUserInfoResponse(userId: Long = TEST_USER_ID): SimpleUserInfoResponse =
+    SimpleUserInfoResponse.from(createTestUser(userId))
+
+fun createTestSimpleUserInfoResponses(size: Int = 5): SimpleUserInfoResponses =
+    SimpleUserInfoResponses(
+        List(size) { userId -> createTestSimpleUserInfoResponse(userId + 1L) },
+    )

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
@@ -1,0 +1,59 @@
+package kr.weit.roadyfoody.admin.presentation.api
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import kr.weit.roadyfoody.admin.application.service.AdminCommandService
+import kr.weit.roadyfoody.admin.application.service.AdminQueryService
+import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
+import kr.weit.roadyfoody.admin.fixture.createTestSimpleUserInfoResponses
+import kr.weit.roadyfoody.auth.fixture.TEST_ACCESS_TOKEN
+import kr.weit.roadyfoody.support.annotation.ControllerTest
+import kr.weit.roadyfoody.user.exception.UserNotFoundException
+import kr.weit.roadyfoody.user.fixture.TEST_NONEXISTENT_ID
+import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(AdminController::class)
+@ControllerTest
+class AdminControllerTest(
+    @MockkBean private val adminCommandService: AdminCommandService,
+    @MockkBean private val adminQueryService: AdminQueryService,
+    private val mockMvc: MockMvc,
+) : BehaviorSpec({
+        val requestUrl = "/api/v1/admin"
+        given("GET $requestUrl/users 테스트") {
+            `when`("정상적으로 요청하면") {
+                every { adminQueryService.getUserInfoList(any()) } returns createTestSimpleUserInfoResponses()
+                then("200 상태코드를 반환한다.") {
+                    mockMvc
+                        .perform(get("$requestUrl/users"))
+                        .andExpect(status().isOk)
+                }
+            }
+        }
+
+        given("GET $requestUrl/users/{userId}/token 테스트") {
+            `when`("정상적으로 요청하면") {
+                every { adminCommandService.getUserAccessToken(TEST_USER_ID) } returns UserAccessTokenResponse(TEST_ACCESS_TOKEN)
+                then("200 상태코드를 반환한다.") {
+                    mockMvc
+                        .perform(get("$requestUrl/users/$TEST_USER_ID/token"))
+                        .andExpect(status().isOk)
+                }
+            }
+
+            `when`("존재하지 않는 userId 로 요청하면") {
+                every { adminCommandService.getUserAccessToken(TEST_NONEXISTENT_ID) } throws
+                    UserNotFoundException("$TEST_NONEXISTENT_ID ID 의 사용자는 존재하지 않습니다.")
+                then("404 상태코드를 반환한다.") {
+                    mockMvc
+                        .perform(get("$requestUrl/users/$TEST_NONEXISTENT_ID/token"))
+                        .andExpect(status().isNotFound)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
@@ -31,6 +31,8 @@ fun createTestUser(
     coin,
 )
 
+fun createTestUsers(size: Int = 5) = List(size) { createTestUser(it.toLong() + 1) }
+
 // fail case
 const val TEST_NONEXISTENT_ID = 0L
 const val TEST_NONEXISTENT_NICKNAME = "JohnDoe"


### PR DESCRIPTION
### 개요
개발환경에서 카카오 로그인 없이 AccessToken 을 구할 수 있도록 백도어 성향의 어드민 API 를 제작했습니다.

### 변경사항
- AdminQueryService 및 테스트 작성
- AdminCommandService 및 테스트 작성
- AdminController 및 테스트 작성
- SecurityConfig PERMITTED_URL_PATTERNS 에 URL 추가


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-105) 


### 리뷰어에게 하고 싶은 말
어떤 피드백이라도 감사히 받겠습니다!
예상하는 사용 플로우는
1. `/api/v1/admin/users` API 를 통해 개발환경에 존재하는 user 들의 
id, nickname, coin 정보들을 조회합니다.
2. `/api/v1/admin/users/{userId}/token` API 를 통해 AccessToken 을 받습니다. (유효기간은 10일이 넘습니다.)