### PR TITLE
ROFO-106 FoodSpots 생성 리포트 작성 시 코인 적립 로직 추가

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.foodSpots.application.service
 
+import jakarta.persistence.EntityManager
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
@@ -14,6 +15,8 @@ import kr.weit.roadyfoody.foodSpots.repository.ReportFoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
 import kr.weit.roadyfoody.foodSpots.repository.getFoodCategories
 import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.mission.domain.RewardPoint
+import kr.weit.roadyfoody.user.application.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -33,6 +36,8 @@ class FoodSpotsCommandService(
     private val foodSpotsCategoryRepository: FoodSpotsFoodCategoryRepository,
     private val imageService: ImageService,
     private val executor: ExecutorService,
+    private val userCommandService: UserCommandService,
+    private val entityManager: EntityManager,
 ) {
     @Transactional
     fun createReport(
@@ -90,5 +95,7 @@ class FoodSpotsCommandService(
                     }, executor)
                 }.forEach { it.join() }
         }
+        entityManager.flush()
+        userCommandService.increaseCoin(user.id, RewardPoint.FIRST_REPORT.point)
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/mission/domain/RewardPoint.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/mission/domain/RewardPoint.kt
@@ -6,4 +6,7 @@ enum class RewardPoint(
     REPORT(100),
     FIRST_REPORT(200),
     CLOSED_REPORT(150),
+    ;
+
+    val point = point
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/mission/domain/RewardPoint.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/mission/domain/RewardPoint.kt
@@ -1,12 +1,9 @@
 package kr.weit.roadyfoody.mission.domain
 
 enum class RewardPoint(
-    point: Int,
+    val point: Int,
 ) {
     REPORT(100),
     FIRST_REPORT(200),
     CLOSED_REPORT(150),
-    ;
-
-    val point = point
 }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -3,8 +3,11 @@ package kr.weit.roadyfoody.foodSpots.application.service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.spyk
+import jakarta.persistence.EntityManager
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsOperationHours
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
@@ -31,6 +34,7 @@ import kr.weit.roadyfoody.foodSpots.repository.ReportFoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
 import kr.weit.roadyfoody.global.service.ImageService
 import kr.weit.roadyfoody.support.utils.ImageFormat
+import kr.weit.roadyfoody.user.application.UserCommandService
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository
@@ -51,6 +55,8 @@ class FoodSpotsCommandServiceTest :
             val foodSpotsCategoryRepository = mockk<FoodSpotsFoodCategoryRepository>()
             val imageService = spyk(ImageService(mockk()))
             val executor = mockk<ExecutorService>()
+            val userCommandService = mockk<UserCommandService>()
+            val entityManager = mockk<EntityManager>()
             val foodSpotsCommandService =
                 FoodSpotsCommandService(
                     foodSpotsRepository,
@@ -63,6 +69,8 @@ class FoodSpotsCommandServiceTest :
                     foodSpotsCategoryRepository,
                     imageService,
                     executor,
+                    userCommandService,
+                    entityManager,
                 )
             val user = createTestUser()
 
@@ -85,6 +93,8 @@ class FoodSpotsCommandServiceTest :
                 every { executor.execute(any()) } answers {
                     firstArg<Runnable>().run()
                 }
+                every { userCommandService.increaseCoin(any(), any()) } just runs
+                every { entityManager.flush() } just runs
                 `when`("정상적인 데이터와 이미지가 들어올 경우") {
                     then("정상적으로 저장되어야 한다.") {
                         foodSpotsCommandService.createReport(


### PR DESCRIPTION
### 개요
기존 FoodSpots 을 생성하는 리포트 생성 기능에 코인 적립 로직을 추가합니다.

### 변경사항
- createReport 메소드에 코인 적립 로직 추가


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-106) 


### 리뷰어에게 하고 싶은 말
지언님께서 너무 고생해주셔서 제가 생각했던것보다 수월했던 것 같네요.

현재는 FoodSpots 생성 리포트 기능(createReport) 만 있어 해당 기능에
첫 리포트의 200 포인트를 적립할 수 있도록 했습니다.

그외 간단한 FoodSpots 변경 리포트 기능은 아직 만들어져 있지 않아 적용하지 못했습니다.
추후에 제작된다면 바로 적용하도록 하겠습니다.

모든 피드백 감사히 받겠습니다!