### PR TITLE
ROFO-103 24시간 이내 코인이 소모된 거리 이내의 검색은 코인 소모를 안함

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/global/config/RedisConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/config/RedisConfig.kt
@@ -1,0 +1,9 @@
+package kr.weit.roadyfoody.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+@Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+class RedisConfig

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
@@ -4,17 +4,26 @@ import jakarta.transaction.Transactional
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsQueryService
+import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchCondition
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponses
+import kr.weit.roadyfoody.search.foodSpots.repository.SearchCoinCacheRepository
 import kr.weit.roadyfoody.user.application.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.stereotype.Service
+import kotlin.math.atan2
+import kotlin.math.cos
 import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+private const val EARTH_RADIUS = 6371
 
 @Service
 class FoodSpotsSearchService(
     private val foodSpotsQueryService: FoodSpotsQueryService,
     private val userCommandService: UserCommandService,
+    private val searchCoinCacheRepository: SearchCoinCacheRepository,
 ) {
     @Transactional
     fun searchFoodSpots(
@@ -24,14 +33,76 @@ class FoodSpotsSearchService(
         val baseRadius = 500
         val searchRadius = foodSpotsSearchQuery.radius
 
+        if (baseRadius == searchRadius) {
+            return foodSpotsQueryService.searchFoodSpots(foodSpotsSearchQuery)
+        }
+
         val additionalRadius = (searchRadius - baseRadius) / baseRadius
         val coinRequired = (2.0.pow(additionalRadius.toDouble()) * 100).toInt()
+        val recentSearches = searchCoinCacheRepository.findByUserId(user.id)
+
+        println(recentSearches.size)
+
+        val existingCache =
+            recentSearches.find { cache ->
+                println(
+                    calculateDistance(
+                        foodSpotsSearchQuery.centerLatitude,
+                        foodSpotsSearchQuery.centerLongitude,
+                        cache.latitude,
+                        cache.longitude,
+                    ),
+                )
+                print("$searchRadius ${cache.radius}")
+                calculateDistance(
+                    foodSpotsSearchQuery.centerLatitude,
+                    foodSpotsSearchQuery.centerLongitude,
+                    cache.latitude,
+                    cache.longitude,
+                ) <= 0.1 &&
+                    searchRadius <= cache.radius
+            }
+
+        if (existingCache != null) {
+            return foodSpotsQueryService.searchFoodSpots(foodSpotsSearchQuery)
+        }
         if (coinRequired > user.coin) {
             throw RoadyFoodyBadRequestException(ErrorCode.COIN_NOT_ENOUGH)
         }
         val foodSpotsSearchResponses = foodSpotsQueryService.searchFoodSpots(foodSpotsSearchQuery)
+
+        val newCache =
+            SearchCoinCache.of(
+                userId = user.id,
+                longitude = foodSpotsSearchQuery.centerLongitude,
+                latitude = foodSpotsSearchQuery.centerLatitude,
+                radius = searchRadius,
+            )
+        searchCoinCacheRepository.save(newCache)
         userCommandService.decreaseCoin(user.id, coinRequired)
 
         return foodSpotsSearchResponses
     }
+
+    fun calculateDistance(
+        startLat: Double,
+        startLong: Double,
+        endLat: Double,
+        endLong: Double,
+    ): Double {
+        var startLat = startLat
+        var endLat = endLat
+        val dLat = Math.toRadians((endLat - startLat))
+        val dLong = Math.toRadians((endLong - startLong))
+
+        startLat = Math.toRadians(startLat)
+        endLat = Math.toRadians(endLat)
+
+        val a = haversine(dLat) + cos(startLat) * cos(endLat) * haversine(dLong)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return EARTH_RADIUS * c
+    }
+
+    fun haversine(`val`: Double): Double = sin(`val` / 2).pow(2.0)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
@@ -104,5 +104,5 @@ class FoodSpotsSearchService(
         return EARTH_RADIUS * c
     }
 
-    fun haversine(`val`: Double): Double = sin(`val` / 2).pow(2.0)
+    fun haversine(value: Double): Double = sin(value / 2).pow(2.0)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
@@ -73,7 +73,7 @@ class FoodSpotsSearchService(
         return foodSpotsSearchResponses
     }
 
-    fun calculateDistance(
+    private fun calculateDistance(
         startLat: Double,
         startLong: Double,
         endLat: Double,

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
@@ -41,19 +41,8 @@ class FoodSpotsSearchService(
         val coinRequired = (2.0.pow(additionalRadius.toDouble()) * 100).toInt()
         val recentSearches = searchCoinCacheRepository.findByUserId(user.id)
 
-        println(recentSearches.size)
-
         val existingCache =
             recentSearches.find { cache ->
-                println(
-                    calculateDistance(
-                        foodSpotsSearchQuery.centerLatitude,
-                        foodSpotsSearchQuery.centerLongitude,
-                        cache.latitude,
-                        cache.longitude,
-                    ),
-                )
-                print("$searchRadius ${cache.radius}")
                 calculateDistance(
                     foodSpotsSearchQuery.centerLatitude,
                     foodSpotsSearchQuery.centerLongitude,

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/domain/SearchCoinCache.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/domain/SearchCoinCache.kt
@@ -1,0 +1,31 @@
+package kr.weit.roadyfoody.search.foodSpots.domain
+
+import jakarta.persistence.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.index.Indexed
+
+@RedisHash("searchCoin", timeToLive = 86400) // 86400초 = 24시간)
+class SearchCoinCache(
+    @Id val id: String,
+    @Indexed
+    val userId: Long,
+    val longitude: Double,
+    val latitude: Double,
+    val radius: Int,
+) {
+    companion object {
+        fun of(
+            userId: Long,
+            longitude: Double,
+            latitude: Double,
+            radius: Int,
+        ): SearchCoinCache =
+            SearchCoinCache(
+                id = "$userId:$longitude:$latitude",
+                userId = userId,
+                longitude = longitude,
+                latitude = latitude,
+                radius = radius,
+            )
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepository.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.search.foodSpots.repository
+
+import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
+import org.springframework.data.repository.CrudRepository
+
+interface SearchCoinCacheRepository : CrudRepository<SearchCoinCache, String> {
+    fun findByUserId(userId: Long): List<SearchCoinCache>
+}

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -18,6 +18,7 @@ import kr.weit.roadyfoody.foodSpots.domain.ReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.utils.FOOD_SPOTS_NAME_MAX_LENGTH
 import kr.weit.roadyfoody.global.utils.CoordinateUtils
+import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponse
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponses
 import kr.weit.roadyfoody.search.foodSpots.dto.OperationStatus
@@ -321,3 +322,19 @@ fun createFoodSpotsSearchResponses(): FoodSpotsSearchResponses =
 
 fun createFoodCategoryResponse(foodCategory: FoodCategory = createTestFoodCategory()): FoodCategoryResponse =
     FoodCategoryResponse.of(foodCategory)
+
+fun createMockSearchCoinCaches(userId: Long): List<SearchCoinCache> =
+    listOf(
+        SearchCoinCache.of(
+            userId = userId,
+            latitude = TEST_FOOD_SPOT_LATITUDE,
+            longitude = TEST_FOOD_SPOT_LONGITUDE + 0.001,
+            radius = 1000,
+        ),
+        SearchCoinCache.of(
+            userId = userId,
+            latitude = TEST_FOOD_SPOT_LATITUDE + 0.001,
+            longitude = TEST_FOOD_SPOT_LONGITUDE,
+            radius = 1500,
+        ),
+    )

--- a/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/application/FoodSpotsSearchServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/application/FoodSpotsSearchServiceTest.kt
@@ -1,14 +1,22 @@
 package kr.weit.roadyfoody.search.foodSpots.application
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.ints.exactly
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsQueryService
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_LATITUDE
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_LONGITUDE
 import kr.weit.roadyfoody.foodSpots.fixture.createFoodSpotsSearchResponses
+import kr.weit.roadyfoody.foodSpots.fixture.createMockSearchCoinCaches
 import kr.weit.roadyfoody.search.foodSpots.application.service.FoodSpotsSearchService
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchCondition
+import kr.weit.roadyfoody.search.foodSpots.repository.SearchCoinCacheRepository
 import kr.weit.roadyfoody.user.application.UserCommandService
 import kr.weit.roadyfoody.user.fixture.createTestUser
 
@@ -16,8 +24,14 @@ class FoodSpotsSearchServiceTest :
     BehaviorSpec({
         val foodSpotsQueryService = mockk<FoodSpotsQueryService>()
         val userCommandService = mockk<UserCommandService>()
+        val searchCoinCacheRepository = mockk<SearchCoinCacheRepository>()
 
-        val foodSpotsSearchService = FoodSpotsSearchService(foodSpotsQueryService, userCommandService)
+        val foodSpotsSearchService =
+            FoodSpotsSearchService(
+                foodSpotsQueryService,
+                userCommandService,
+                searchCoinCacheRepository,
+            )
 
         afterEach { clearAllMocks() }
 
@@ -30,15 +44,59 @@ class FoodSpotsSearchServiceTest :
                     name = null,
                     categoryIds = emptyList(),
                 )
-            `when`("코인이 있고 1000m이내 가게 검색을 요청하면") {
+            `when`("코인이 있고 1000m이내 가게 검색을 요청하면 - 코인 캐싱 x") {
 
                 val user = createTestUser(coin = 1000)
-                every { userCommandService.decreaseCoin(any(), any()) } returns Unit
+                every { searchCoinCacheRepository.findByUserId(user.id) } returns emptyList()
+                every { searchCoinCacheRepository.save(any()) } returns mockk()
+                every { userCommandService.decreaseCoin(any(), any()) } just runs
                 every { foodSpotsQueryService.searchFoodSpots(query1000m) } returns createFoodSpotsSearchResponses()
 
                 then("정상적으로 검색되어야 한다.") {
                     val result = foodSpotsSearchService.searchFoodSpots(user, query1000m)
+                    verify(exactly = 1) { userCommandService.decreaseCoin(user.id, 200) }
+                    verify(exactly = 1) { searchCoinCacheRepository.save(any()) }
                     result shouldBe createFoodSpotsSearchResponses()
+                }
+            }
+            val query1000mWithCache =
+                FoodSpotsSearchCondition(
+                    centerLongitude = TEST_FOOD_SPOT_LONGITUDE,
+                    centerLatitude = TEST_FOOD_SPOT_LATITUDE,
+                    radius = 1000,
+                    name = null,
+                    categoryIds = emptyList(),
+                )
+            `when`("코인이 있고 1000m이내 가게 검색을 요청하면 - 코인 캐싱 o") {
+                val user = createTestUser(coin = 1000)
+                every { searchCoinCacheRepository.findByUserId(user.id) } returns createMockSearchCoinCaches(user.id)
+                every { foodSpotsQueryService.searchFoodSpots(query1000mWithCache) } returns createFoodSpotsSearchResponses()
+
+                then("정상적으로 검색되어야 한다.") {
+                    val result = foodSpotsSearchService.searchFoodSpots(user, query1000mWithCache)
+                    verify(exactly = 0) { userCommandService.decreaseCoin(user.id, 200) }
+                    verify(exactly = 0) { searchCoinCacheRepository.save(any()) }
+                    result shouldBe createFoodSpotsSearchResponses()
+                }
+            }
+
+            `when`("500m 거리 이내 가게 검색 조회를 하면") {
+                val query500m =
+                    FoodSpotsSearchCondition(
+                        centerLongitude = 0.0,
+                        centerLatitude = 0.0,
+                        radius = 500,
+                        name = null,
+                        categoryIds = emptyList(),
+                    )
+                val user = createTestUser(coin = 1000)
+                every { userCommandService.decreaseCoin(any(), any()) } returns Unit
+                every { foodSpotsQueryService.searchFoodSpots(query500m) } returns createFoodSpotsSearchResponses()
+                then("코인 소모와 캐싱 없이 결과를 반환한다.") {
+                    val result = foodSpotsSearchService.searchFoodSpots(user, query500m)
+                    result shouldBe createFoodSpotsSearchResponses()
+                    verify(exactly = 0) { searchCoinCacheRepository.save(any()) }
+                    verify(exactly = 0) { userCommandService.decreaseCoin(any(), any()) }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepositoryTest.kt
@@ -33,7 +33,6 @@ class SearchCoinCacheRepositoryTest
                         val result = searchCoinCacheRepository.findByUserId(0L)
                         result shouldHaveSize searchCoinCaches.size
                         result.forEachIndexed { index, cache ->
-                            print("${cache.id} ${cache.radius} ${searchCoinCaches[index].id}")
                             cache.id shouldBe searchCoinCaches[index].id
                         }
                     }

--- a/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/repository/SearchCoinCacheRepositoryTest.kt
@@ -1,0 +1,42 @@
+package kr.weit.roadyfoody.search.foodSpots.repository
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kr.weit.roadyfoody.foodSpots.fixture.createMockSearchCoinCaches
+import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
+import kr.weit.roadyfoody.support.config.testcontainers.TestContainersConfig
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@ActiveProfiles("test")
+@Testcontainers
+@ContextConfiguration(initializers = [TestContainersConfig.Initializer::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+class SearchCoinCacheRepositoryTest
+    @Autowired
+    constructor(
+        private val searchCoinCacheRepository: SearchCoinCacheRepository,
+    ) : DescribeSpec({
+            describe("findSearchCoinCachesByUserId 메소드는") {
+                context("존재하는 user id 를 받는 경우") {
+                    it("해당 user 의 SearchCoinCache 리스트를 반환한다.") {
+                        val searchCoinCaches =
+                            searchCoinCacheRepository.saveAll(
+                                createMockSearchCoinCaches(0L),
+                            ) as List<SearchCoinCache>
+                        val result = searchCoinCacheRepository.findByUserId(0L)
+                        result shouldHaveSize searchCoinCaches.size
+                        result.forEachIndexed { index, cache ->
+                            print("${cache.id} ${cache.radius} ${searchCoinCaches[index].id}")
+                            cache.id shouldBe searchCoinCaches[index].id
+                        }
+                    }
+                }
+            }
+        })


### PR DESCRIPTION
### 개요

### 변경사항
- redis 검색 결과 entity, repository 생성
- 코인 소모 로직에 캐싱


### 테스트
- 테스트 코드 추가여부 O/X O
- 테스트 코드가 추가되지 않았다면 그 이유를 적어주세요.

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-103) 


### 리뷰어에게 하고 싶은 말
redis를 사용하기 위해 entity와 repository를 생성하여 개발하였습니다.
코인 소모안하는 경우(and)
1. 24시간 이내 검색 결과중 100m 이내 검색 기록이 존재
2. 해당 기록의 반경이 현재 검색 조건 반경 넓은 경우 (ex - 과거 검색 1500m 현재 검색 1000m)
피드백 환영합니다.
