### PR TITLE
ROFO-119 음식점 정보 수정 리포트 API 작성

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -72,6 +72,7 @@ enum class ErrorCode(
         "시간은 00:00부터 23:59까지의 형식이어야 합니다.",
     ),
     NOT_FOUND_FOOD_CATEGORY(HttpStatus.NOT_FOUND, -10011, "해당 카테고리가 존재하지 않습니다."),
+    INVALID_CHANGE_VALUE(HttpStatus.BAD_REQUEST, -10000, "변경할 값이 없습니다."),
 
     // Review API error 14000대
     FOOD_SPOT_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -10000, "음식점 ID는 양수여야 합니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -72,7 +72,8 @@ enum class ErrorCode(
         "시간은 00:00부터 23:59까지의 형식이어야 합니다.",
     ),
     NOT_FOUND_FOOD_CATEGORY(HttpStatus.NOT_FOUND, -10011, "해당 카테고리가 존재하지 않습니다."),
-    INVALID_CHANGE_VALUE(HttpStatus.BAD_REQUEST, -10000, "변경할 값이 없습니다."),
+    INVALID_CHANGE_VALUE(HttpStatus.BAD_REQUEST, -13000, "변경할 값이 없습니다."),
+    NON_POSITIVE_FOOD_SPOT_ID(HttpStatus.BAD_REQUEST, -13000, "음식점 ID는 양수여야 합니다."),
 
     // Review API error 14000대
     FOOD_SPOT_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -10000, "음식점 ID는 양수여야 합니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
@@ -176,3 +176,53 @@ data class ReportCategoryResponse(
         name = reportFoodCategory.foodCategory.name,
     )
 }
+
+data class FoodSpotsUpdateRequest(
+    @field:Pattern(regexp = FOOD_SPOTS_NAME_REGEX_STR, message = FOOD_SPOTS_NAME_REGEX_DESC)
+    @Schema(
+        description =
+            "상호명 : $FOOD_SPOTS_NAME_REGEX_DESC\t(허용된 특수문자 : 마침표 (.) 쉼표 (,) 작은따옴표 (') 가운데점 (·) 앰퍼샌드 (&) 하이픈 (-))",
+        example = "명륜진사갈비 본사",
+    )
+    val name: String?,
+    @field:Longitude
+    @Schema(description = "경도", example = "127.12312219099")
+    val longitude: Double?,
+    @field:Latitude
+    @Schema(description = "위도", example = "37.4940529587731")
+    val latitude: Double?,
+    @Schema(description = "영업 여부", example = "true")
+    val open: Boolean?,
+    @Schema(description = "폐업 여부", example = "false")
+    val closed: Boolean?,
+    @field:NotEmpty(message = "음식 카테고리는 최소 1개 이상 선택해야 합니다.")
+    @Schema(description = "음식 카테고리", example = "[1, 2]")
+    val foodCategories: Set<Long>,
+    @field:Valid
+    @Schema(
+        description = "운영시간 리스트 ex) 사용자가 월/수/금의 운영시간 입력-> 월/수/금 데이터만 보내주세요. 없을 경우, 빈 배열",
+    )
+    val operationHours: List<OperationHoursRequest>,
+) {
+    fun toReportRequest(foodSpots: FoodSpots) =
+        ReportRequest(
+            name = this.name ?: foodSpots.name,
+            longitude = this.longitude ?: foodSpots.point.x,
+            latitude = this.latitude ?: foodSpots.point.y,
+            foodTruck = foodSpots.foodTruck,
+            open = this.open ?: foodSpots.open,
+            closed = this.closed ?: foodSpots.storeClosure,
+            foodCategories = this.foodCategories,
+            operationHours = this.operationHours,
+        )
+
+    fun toOperationHoursEntity(foodSpots: FoodSpots) =
+        operationHours.map {
+            FoodSpotsOperationHours(
+                foodSpots = foodSpots,
+                dayOfWeek = it.dayOfWeek,
+                openingHours = it.openingHours,
+                closingHours = it.closingHours,
+            )
+        }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
 import kr.weit.roadyfoody.foodSpots.domain.DayOfWeek
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
@@ -195,11 +196,15 @@ data class FoodSpotsUpdateRequest(
     val open: Boolean?,
     @Schema(description = "폐업 여부", example = "false")
     val closed: Boolean?,
-    @Schema(description = "음식 카테고리", example = "[1, 2]")
+    @field:Size(min = 1, message = "음식 카테고리는 최소 1개 이상 선택해야 합니다.")
+    @Schema(
+        description = "음식 카테고리 ex) 변경된, 변경되지 않은 카테고리 모두 입력해주세요. 없을 경우, 생략해주세요",
+        example = "[1, 2]",
+    )
     val foodCategories: Set<Long>?,
     @field:Valid
     @Schema(
-        description = "운영시간 리스트 ex) 사용자가 월/수/금의 운영시간 입력-> 월/수/금 데이터만 보내주세요. 없을 경우, 빈 배열",
+        description = "운영시간 리스트 ex) 변경된, 변경되지 않은 운영시간 모두 입력해주세요. 없을 경우, 생략해주세요",
     )
     val operationHours: List<OperationHoursRequest>?,
 ) {

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -1,9 +1,13 @@
 package kr.weit.roadyfoody.foodSpots.application.service
 
 import jakarta.persistence.EntityManager
+import kr.weit.roadyfoody.common.exception.ErrorCode
+import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
+import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
+import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
 import kr.weit.roadyfoody.foodSpots.domain.ReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.repository.FoodCategoryRepository
@@ -14,8 +18,10 @@ import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsPhotoRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsRepository
 import kr.weit.roadyfoody.foodSpots.repository.ReportFoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
+import kr.weit.roadyfoody.foodSpots.repository.getByFoodSpotsId
 import kr.weit.roadyfoody.foodSpots.repository.getFoodCategories
 import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.global.utils.CoordinateUtils.Companion.createCoordinate
 import kr.weit.roadyfoody.mission.domain.RewardPoint
 import kr.weit.roadyfoody.user.application.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
@@ -47,7 +53,25 @@ class FoodSpotsCommandService(
         photos: List<MultipartFile>?,
     ) {
         val foodSpots = storeFoodSpots(reportRequest)
-        storeReport(reportRequest, foodSpots, user, photos)
+        val foodStoreHistory = storeReport(reportRequest, foodSpots, user)
+        val generatorPhotoNameMap =
+            photos?.associateBy { imageService.generateImageName(it) } ?: emptyMap()
+
+        generatorPhotoNameMap
+            .map {
+                FoodSpotsPhoto.of(foodStoreHistory, it.key)
+            }.also { foodSpotsPhotoRepository.saveAll(it) }
+
+        entityManager.flush()
+
+        userCommandService.increaseCoin(user.id, RewardPoint.FIRST_REPORT.point)
+
+        generatorPhotoNameMap
+            .map {
+                CompletableFuture.supplyAsync({
+                    imageService.upload(it.key, it.value)
+                }, executor)
+            }.forEach { it.join() }
     }
 
     private fun storeFoodSpots(reportRequest: ReportRequest): FoodSpots {
@@ -65,12 +89,42 @@ class FoodSpotsCommandService(
         return foodSpots
     }
 
+    @Transactional
+    fun doUpdateReport(
+        user: User,
+        foodSpotsId: Long,
+        request: FoodSpotsUpdateRequest,
+    ) {
+        val foodSpots = foodSpotsRepository.getByFoodSpotsId(foodSpotsId)
+
+        val changed =
+            run {
+                val foodSpotsUpdated = updateFoodSpots(foodSpots, request)
+                val categoriesUpdated = updateFoodSpotsCategories(foodSpots, request)
+                val operationHoursUpdated = updateFoodSpotsOperationHours(foodSpots, request)
+                foodSpotsUpdated || categoriesUpdated || operationHoursUpdated
+            }
+
+        if (!changed) {
+            throw RoadyFoodyBadRequestException(ErrorCode.INVALID_CHANGE_VALUE)
+        }
+
+        storeReport(request.toReportRequest(foodSpots), foodSpots, user)
+
+        entityManager.flush()
+
+        if (request.closed != null && request.closed) {
+            userCommandService.increaseCoin(user.id, RewardPoint.CLOSED_REPORT.point)
+        } else {
+            userCommandService.increaseCoin(user.id, RewardPoint.REPORT.point)
+        }
+    }
+
     private fun storeReport(
         reportRequest: ReportRequest,
         foodSpots: FoodSpots,
         user: User,
-        photos: List<MultipartFile>? = null,
-    ) {
+    ): FoodSpotsHistory {
         val foodStoreHistory = reportRequest.toFoodSpotsHistoryEntity(foodSpots, user)
         foodSpotsHistoryRepository.save(foodStoreHistory)
 
@@ -83,23 +137,77 @@ class FoodSpotsCommandService(
             reportRequest.toReportOperationHoursEntity(foodStoreHistory),
         )
 
-        val generatorPhotoNameMap =
-            photos?.associateBy { imageService.generateImageName(it) } ?: emptyMap()
+        return foodStoreHistory
+    }
 
-        generatorPhotoNameMap
-            .map {
-                FoodSpotsPhoto.of(foodStoreHistory, it.key)
-            }.also { foodSpotsPhotoRepository.saveAll(it) }
+    private fun updateFoodSpots(
+        foodSpots: FoodSpots,
+        request: FoodSpotsUpdateRequest,
+    ): Boolean {
+        var changed = false
+        if (request.name != null && request.name != foodSpots.name) {
+            foodSpots.name = request.name
+            changed = true
+        }
+        if (request.longitude != null && request.latitude != null) {
+            val point = createCoordinate(request.longitude, request.latitude)
+            if (point != foodSpots.point) {
+                foodSpots.point = point
+                changed = true
+            }
+        }
+        if (request.open != null && request.open != foodSpots.open) {
+            foodSpots.open = request.open
+            changed = true
+        }
+        if (request.closed != null && request.closed != foodSpots.storeClosure) {
+            foodSpots.storeClosure = request.closed
+            changed = true
+        }
+        return changed
+    }
 
-        entityManager.flush()
-        userCommandService.increaseCoin(user.id, RewardPoint.FIRST_REPORT.point)
+    private fun updateFoodSpotsCategories(
+        foodSpots: FoodSpots,
+        request: FoodSpotsUpdateRequest,
+    ): Boolean {
+        val currentFoodCategoryIds = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet()
+        val newFoodCategoryIds = request.foodCategories
 
-        generatorPhotoNameMap
-            .map {
-                CompletableFuture.supplyAsync({
-                    imageService.upload(it.key, it.value)
-                }, executor)
-            }.forEach { it.join() }
+        val categoryIdsToRemove = currentFoodCategoryIds subtract newFoodCategoryIds
+        val foodSpotsFoodCategoryToRemove = foodSpots.foodCategoryList.filter { it.foodCategory.id in categoryIdsToRemove }
+        foodSpotsCategoryRepository.deleteAll(foodSpotsFoodCategoryToRemove)
+
+        val categoryIdsToAdd = newFoodCategoryIds subtract currentFoodCategoryIds
+        val foodCategoriesToAdd =
+            if (categoryIdsToAdd.isNotEmpty()) {
+                foodCategoryRepository.getFoodCategories(categoryIdsToAdd)
+            } else {
+                emptyList()
+            }
+
+        val foodSpotsFoodCategoriesToAdd = foodCategoriesToAdd.map { FoodSpotsFoodCategory(foodSpots, it) }
+        foodSpotsCategoryRepository.saveAll(foodSpotsFoodCategoriesToAdd)
+
+        val changed = categoryIdsToRemove.isNotEmpty() || categoryIdsToAdd.isNotEmpty()
+        return changed
+    }
+
+    private fun updateFoodSpotsOperationHours(
+        foodSpots: FoodSpots,
+        request: FoodSpotsUpdateRequest,
+    ): Boolean {
+        val currentFoodSpotsOperationHours = foodSpots.operationHoursList.toSet()
+        val newFoodSpotsOperationHours = request.toOperationHoursEntity(foodSpots).toSet()
+
+        val foodSpotsOperationHoursToRemove = currentFoodSpotsOperationHours subtract newFoodSpotsOperationHours
+        foodSportsOperationHoursRepository.deleteAll(foodSpotsOperationHoursToRemove)
+
+        val foodSpotsOperationHoursToAdd = newFoodSpotsOperationHours subtract currentFoodSpotsOperationHours
+        foodSportsOperationHoursRepository.saveAll(foodSpotsOperationHoursToAdd)
+
+        val changed = foodSpotsOperationHoursToRemove.isNotEmpty() || foodSpotsOperationHoursToAdd.isNotEmpty()
+        return changed
     }
 
     @Transactional

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -5,6 +5,7 @@ import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
+import kr.weit.roadyfoody.foodSpots.application.dto.toIds
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
@@ -171,7 +172,11 @@ class FoodSpotsCommandService(
         foodSpots: FoodSpots,
         request: FoodSpotsUpdateRequest,
     ): Boolean {
-        val currentFoodCategoryIds = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet()
+        if (request.foodCategories == null) {
+            return false
+        }
+
+        val currentFoodCategoryIds = foodSpots.foodCategoryList.toIds()
         val newFoodCategoryIds = request.foodCategories
 
         val categoryIdsToRemove = currentFoodCategoryIds subtract newFoodCategoryIds
@@ -198,7 +203,7 @@ class FoodSpotsCommandService(
         request: FoodSpotsUpdateRequest,
     ): Boolean {
         val currentFoodSpotsOperationHours = foodSpots.operationHoursList.toSet()
-        val newFoodSpotsOperationHours = request.toOperationHoursEntity(foodSpots).toSet()
+        val newFoodSpotsOperationHours = request.toOperationHoursEntity(foodSpots) ?: return false
 
         val foodSpotsOperationHoursToRemove = currentFoodSpotsOperationHours subtract newFoodSpotsOperationHours
         foodSportsOperationHoursRepository.deleteAll(foodSpotsOperationHoursToRemove)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsOperationHours.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsOperationHours.kt
@@ -43,4 +43,23 @@ class FoodSpotsOperationHours(
         require(OPERATION_HOURS_REGEX.matches(openingHours)) { OPERATION_HOURS_REGEX_DESC }
         require(OPERATION_HOURS_REGEX.matches(closingHours)) { OPERATION_HOURS_REGEX_DESC }
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FoodSpotsOperationHours) return false
+        if (foodSpots.id != other.foodSpots.id) return false
+        if (dayOfWeek != other.dayOfWeek) return false
+        if (openingHours != other.openingHours) return false
+        if (closingHours != other.closingHours) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = foodSpots.id.hashCode()
+        result = 31 * result + dayOfWeek.hashCode()
+        result = 31 * result + openingHours.hashCode()
+        result = 31 * result + closingHours.hashCode()
+        return result
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
@@ -65,6 +65,7 @@ class FoodSpotsController(
     override fun updateFoodSpots(
         @LoginUser
         user: User,
+        @Positive(message = "음식점 ID는 양수여야 합니다.")
         @PathVariable("foodSpotsId")
         foodSpotsId: Long,
         @Valid

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.dto.SliceResponse
+import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportHistoriesResponse
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService
@@ -13,10 +14,13 @@ import kr.weit.roadyfoody.foodSpots.presentation.spec.FoodSportsControllerSpec
 import kr.weit.roadyfoody.foodSpots.validator.WebPImageList
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
@@ -55,4 +59,18 @@ class FoodSpotsController(
         @RequestParam(required = false)
         lastId: Long?,
     ): SliceResponse<ReportHistoriesResponse> = foodSpotsQueryService.getReportHistories(userId, size, lastId)
+
+    @ResponseStatus(NO_CONTENT)
+    @PatchMapping("/{foodSpotsId}")
+    override fun updateFoodSpots(
+        @LoginUser
+        user: User,
+        @PathVariable("foodSpotsId")
+        foodSpotsId: Long,
+        @Valid
+        @RequestBody
+        request: FoodSpotsUpdateRequest,
+    ) {
+        foodSpotsCommandService.doUpdateReport(user, foodSpotsId, request)
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
@@ -14,7 +14,6 @@ import kr.weit.roadyfoody.foodSpots.presentation.spec.FoodSportsControllerSpec
 import kr.weit.roadyfoody.foodSpots.validator.WebPImageList
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.http.HttpStatus.CREATED
-import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -60,7 +59,7 @@ class FoodSpotsController(
         lastId: Long?,
     ): SliceResponse<ReportHistoriesResponse> = foodSpotsQueryService.getReportHistories(userId, size, lastId)
 
-    @ResponseStatus(NO_CONTENT)
+    @ResponseStatus(CREATED)
     @PatchMapping("/{foodSpotsId}")
     override fun updateFoodSpots(
         @LoginUser

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -154,6 +154,7 @@ interface FoodSportsControllerSpec {
     )
     fun updateFoodSpots(
         user: User,
+        @Positive(message = "음식점 ID는 양수여야 합니다.")
         @Parameter(description = "음식점 ID", required = true, example = "1")
         foodSpotsId: Long,
         @Valid

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -14,6 +14,7 @@ import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.dto.SliceResponse
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.ErrorResponse
+import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportHistoriesResponse
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.utils.SliceReportHistories
@@ -127,4 +128,35 @@ interface FoodSportsControllerSpec {
         @RequestParam(required = false)
         lastId: Long?,
     ): SliceResponse<ReportHistoriesResponse>
+
+    @Operation(
+        description = "음식점 정보 수정 API",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "음식점 정보 수정 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.INVALID_LENGTH_FOOD_SPOTS_NAME,
+            ErrorCode.INVALID_CHARACTERS_FOOD_SPOTS_NAME,
+            ErrorCode.LATITUDE_TOO_HIGH,
+            ErrorCode.LATITUDE_TOO_LOW,
+            ErrorCode.LONGITUDE_TOO_HIGH,
+            ErrorCode.LONGITUDE_TOO_LOW,
+            ErrorCode.NO_CATEGORY_SELECTED,
+            ErrorCode.INVALID_FORMAT_OPERATION_HOURS,
+            ErrorCode.NOT_FOUND_FOOD_CATEGORY,
+            ErrorCode.INVALID_CHANGE_VALUE,
+        ],
+    )
+    fun updateFoodSpots(
+        user: User,
+        @Parameter(description = "음식점 ID", required = true, example = "1")
+        foodSpotsId: Long,
+        @Valid
+        request: FoodSpotsUpdateRequest,
+    )
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -150,6 +150,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.INVALID_FORMAT_OPERATION_HOURS,
             ErrorCode.NOT_FOUND_FOOD_CATEGORY,
             ErrorCode.INVALID_CHANGE_VALUE,
+            ErrorCode.NON_POSITIVE_FOOD_SPOT_ID,
         ],
     )
     fun updateFoodSpots(

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -133,7 +133,7 @@ interface FoodSportsControllerSpec {
         description = "음식점 정보 수정 API",
         responses = [
             ApiResponse(
-                responseCode = "204",
+                responseCode = "201",
                 description = "음식점 정보 수정 성공",
             ),
         ],

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -13,7 +13,6 @@ import io.mockk.spyk
 import jakarta.persistence.EntityManager
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.dto.OperationHoursRequest
-import kr.weit.roadyfoody.foodSpots.application.dto.toIds
 import kr.weit.roadyfoody.foodSpots.domain.DayOfWeek
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsOperationHours
@@ -264,7 +263,9 @@ class FoodSpotsCommandServiceTest :
                     val onlyCategoryAddRequest =
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
                             .copy(
-                                foodCategories = foodSpots.foodCategoryList.toIds() + newCategory.id,
+                                foodCategories =
+                                    foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() +
+                                        newCategory.id,
                             )
 
                     then("정상적으로 업데이트 되어야 한다.") {
@@ -294,7 +295,11 @@ class FoodSpotsCommandServiceTest :
                         listOf(createTestReportOperationHours())
                     val onlyCategoryDeleteRequest =
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
-                            .copy(foodCategories = foodSpots.foodCategoryList.toIds() - lastCategoryId)
+                            .copy(
+                                foodCategories =
+                                    foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() -
+                                        lastCategoryId,
+                            )
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
@@ -328,7 +333,9 @@ class FoodSpotsCommandServiceTest :
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
                             .copy(
                                 foodCategories =
-                                    foodSpots.foodCategoryList.toIds() + newCategory.id - lastCategoryIdToRemove,
+                                    foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() +
+                                        newCategory.id -
+                                        lastCategoryIdToRemove,
                             )
 
                     then("정상적으로 업데이트 되어야 한다.") {

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -13,6 +13,7 @@ import io.mockk.spyk
 import jakarta.persistence.EntityManager
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.dto.OperationHoursRequest
+import kr.weit.roadyfoody.foodSpots.application.dto.toIds
 import kr.weit.roadyfoody.foodSpots.domain.DayOfWeek
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsOperationHours
@@ -263,7 +264,7 @@ class FoodSpotsCommandServiceTest :
                     val onlyCategoryAddRequest =
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
                             .copy(
-                                foodCategories = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() + newCategory.id,
+                                foodCategories = foodSpots.foodCategoryList.toIds() + newCategory.id,
                             )
 
                     then("정상적으로 업데이트 되어야 한다.") {
@@ -293,7 +294,7 @@ class FoodSpotsCommandServiceTest :
                         listOf(createTestReportOperationHours())
                     val onlyCategoryDeleteRequest =
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
-                            .copy(foodCategories = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() - lastCategoryId)
+                            .copy(foodCategories = foodSpots.foodCategoryList.toIds() - lastCategoryId)
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
@@ -327,7 +328,7 @@ class FoodSpotsCommandServiceTest :
                         createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
                             .copy(
                                 foodCategories =
-                                    foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() + newCategory.id - lastCategoryIdToRemove,
+                                    foodSpots.foodCategoryList.toIds() + newCategory.id - lastCategoryIdToRemove,
                             )
 
                     then("정상적으로 업데이트 되어야 한다.") {

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -1,26 +1,41 @@
 package kr.weit.roadyfoody.foodSpots.application.service
 
+import TEST_FOOD_SPOT_ID
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import jakarta.persistence.EntityManager
+import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
+import kr.weit.roadyfoody.foodSpots.application.dto.OperationHoursRequest
+import kr.weit.roadyfoody.foodSpots.domain.DayOfWeek
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsOperationHours
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
 import kr.weit.roadyfoody.foodSpots.domain.ReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.exception.CategoriesNotFoundException
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_NEW_CATEGORY_NAME
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_UPDATE_FOOD_SPOT_LATITUDE
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_UPDATE_FOOD_SPOT_LONGITUDE
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_UPDATE_FOOD_SPOT_NAME
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_UPDATE_OPERATION_HOURS_CLOSE
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_UPDATE_OPERATION_HOURS_OPEN
 import kr.weit.roadyfoody.foodSpots.fixture.createMockPhotoList
 import kr.weit.roadyfoody.foodSpots.fixture.createMockTestFoodHistory
 import kr.weit.roadyfoody.foodSpots.fixture.createMockTestFoodSpot
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodCategories
 import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodCategory
 import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodOperationHours
-import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsFoodCategory
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsFoodCategories
 import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsPhoto
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsUpdateRequest
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsUpdateRequestFromEntity
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportOperationHours
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportRequest
@@ -87,7 +102,7 @@ class FoodSpotsCommandServiceTest :
                 every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
                     listOf(createTestReportFoodCategory())
                 every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
-                    createTestFoodSpotsFoodCategory()
+                    createTestFoodSpotsFoodCategories()
                 every { foodSpotsPhotoRepository.saveAll(any<List<FoodSpotsPhoto>>()) } returns
                     listOf(createTestFoodSpotsPhoto())
                 every { executor.execute(any()) } answers {
@@ -118,7 +133,7 @@ class FoodSpotsCommandServiceTest :
                 `when`("카테고리가 전부 존재하지 않을 경우") {
                     every { userRepository.findById(TEST_USER_ID) } returns Optional.of(user)
                     every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns emptyList()
-                    then("CategoriesNotFoundException이 발생한다.") {
+                    then("CategoriesNotFoundException 이 발생한다.") {
                         shouldThrow<CategoriesNotFoundException> {
                             foodSpotsCommandService.createReport(
                                 createTestUser(),
@@ -129,6 +144,268 @@ class FoodSpotsCommandServiceTest :
                     }
                 }
             }
+
+            given("doUpdateReport 테스트") {
+                `when`("정상적인 데이터가 들어올 경우") {
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(createMockTestFoodSpot())
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories()
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    every { entityManager.flush() } just runs
+                    every { imageService.upload(any(), any()) } just runs
+                    every { userCommandService.increaseCoin(any(), any()) } just runs
+
+                    val foodSpotsUpdateRequest = createTestFoodSpotsUpdateRequest()
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            foodSpotsUpdateRequest,
+                        )
+                    }
+                }
+
+                `when`("음식점 이름만 변경할 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories()
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val onlyNameChangeRequest =
+                        createTestFoodSpotsUpdateRequestFromEntity(
+                            foodSpots,
+                        ).copy(name = TEST_UPDATE_FOOD_SPOT_NAME)
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            onlyNameChangeRequest,
+                        )
+                    }
+                }
+
+                `when`("경도와 위도만 변경할 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories()
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val onlyCoordinateChangeRequest = createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        forAll(
+                            row(onlyCoordinateChangeRequest.copy(longitude = TEST_UPDATE_FOOD_SPOT_LONGITUDE)),
+                            row(onlyCoordinateChangeRequest.copy(latitude = TEST_UPDATE_FOOD_SPOT_LATITUDE)),
+                            row(
+                                onlyCoordinateChangeRequest.copy(
+                                    longitude = TEST_UPDATE_FOOD_SPOT_LONGITUDE,
+                                    latitude = TEST_UPDATE_FOOD_SPOT_LATITUDE,
+                                ),
+                            ),
+                        ) { request ->
+                            foodSpotsCommandService.doUpdateReport(
+                                createTestUser(),
+                                TEST_FOOD_SPOT_ID,
+                                request,
+                            )
+                        }
+                    }
+                }
+
+                `when`("카테고리만 추가될 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    val newCategory = createTestFoodCategory(id = 10, name = TEST_NEW_CATEGORY_NAME)
+                    // storeReport 시 request category 전체를 조회
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories() + newCategory
+                    // updateFoodSpotsCategory 시 새로 추가되어야하는 category 만 조회
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(setOf(newCategory.id)) } returns listOf(newCategory)
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val onlyCategoryAddRequest =
+                        createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+                            .copy(
+                                foodCategories = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() + newCategory.id,
+                            )
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            onlyCategoryAddRequest,
+                        )
+                    }
+                }
+
+                `when`("카테고리만 삭제될 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    val lastCategoryId = createTestFoodCategories().last().id
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories().dropLast(1)
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val onlyCategoryDeleteRequest =
+                        createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+                            .copy(foodCategories = foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() - lastCategoryId)
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            onlyCategoryDeleteRequest,
+                        )
+                    }
+                }
+
+                `when`("카테고리 추가와 삭제가 동시에 일어날 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    val newCategory = createTestFoodCategory(id = 10, name = TEST_NEW_CATEGORY_NAME)
+                    val lastCategoryIdToRemove = createTestFoodCategories().last().id
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns
+                        createTestFoodCategories().dropLast(1) + newCategory
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(setOf(newCategory.id)) } returns listOf(newCategory)
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val categoryAddAndDeleteRequest =
+                        createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+                            .copy(
+                                foodCategories =
+                                    foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet() + newCategory.id - lastCategoryIdToRemove,
+                            )
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            categoryAddAndDeleteRequest,
+                        )
+                    }
+                }
+
+                `when`("운영시간이 변경될 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories()
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+                    val onlyOperationHoursChangeRequest =
+                        createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+                            .copy(
+                                operationHours =
+                                    listOf(
+                                        OperationHoursRequest(
+                                            dayOfWeek = DayOfWeek.MON,
+                                            openingHours = TEST_UPDATE_OPERATION_HOURS_OPEN,
+                                            closingHours = TEST_UPDATE_OPERATION_HOURS_CLOSE,
+                                        ),
+                                    ),
+                            )
+
+                    then("정상적으로 업데이트 되어야 한다.") {
+                        foodSpotsCommandService.doUpdateReport(
+                            createTestUser(),
+                            TEST_FOOD_SPOT_ID,
+                            onlyOperationHoursChangeRequest,
+                        )
+                    }
+                }
+
+                `when`("변경된 값이 없을 경우") {
+                    val foodSpots = createMockTestFoodSpot()
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    every { foodSpotsCategoryRepository.deleteAll(any<List<FoodSpotsFoodCategory>>()) } just runs
+                    every { foodCategoryRepository.findFoodCategoryByIdIn(any()) } returns createTestFoodCategories()
+                    every { foodSpotsCategoryRepository.saveAll(any<List<FoodSpotsFoodCategory>>()) } returns
+                        createTestFoodSpotsFoodCategories()
+                    every { foodSportsOperationHoursRepository.deleteAll(any<List<FoodSpotsOperationHours>>()) } just runs
+                    every { foodSportsOperationHoursRepository.saveAll(any<List<FoodSpotsOperationHours>>()) } returns
+                        listOf(createTestFoodOperationHours())
+                    every { foodSpotsHistoryRepository.save(any()) } returns createMockTestFoodHistory()
+                    every { reportFoodCategoryRepository.saveAll(any<List<ReportFoodCategory>>()) } returns
+                        listOf(createTestReportFoodCategory())
+                    every { reportOperationHoursRepository.saveAll(any<List<ReportOperationHours>>()) } returns
+                        listOf(createTestReportOperationHours())
+
+                    val noChangeRequest = createTestFoodSpotsUpdateRequestFromEntity(foodSpots)
+
+                    then("변경된 값이 없으므로 RoadyFoodyBadRequestException 이 발생해야 한다.") {
+                        shouldThrow<RoadyFoodyBadRequestException> {
+                            foodSpotsCommandService.doUpdateReport(
+                                createTestUser(),
+                                TEST_FOOD_SPOT_ID,
+                                noChangeRequest,
+                            )
+                        }
+                    }
+                }
+            }
+
             given("deleteWithdrawUserReport 테스트") {
                 `when`("유저 삭제 요청이 들어올 경우") {
                     every { foodSpotsHistoryRepository.findByUser(any()) } returns

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -1,6 +1,7 @@
 package kr.weit.roadyfoody.foodSpots.fixture
 
 import kr.weit.roadyfoody.foodSpots.application.dto.FoodCategoryResponse
+import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.OperationHoursRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportCategoryResponse
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportHistoriesResponse
@@ -58,8 +59,23 @@ const val TEST_OPERATION_HOURS_OPEN = "00:00"
 const val TEST_OPERATION_HOURS_CLOSE = "23:59"
 const val TEST_INVALID_TIME_FORMAT = "25:60"
 const val TEST_CATEGORY_NAME = "붕어빵"
+const val TEST_NEW_CATEGORY_NAME = "백반"
+const val TEST_UPDATE_FOOD_SPOT_NAME = "updateFoodSpot"
+const val TEST_UPDATE_FOOD_SPOT_LATITUDE = 11.1111111
+const val TEST_UPDATE_FOOD_SPOT_LONGITUDE = 11.2222222
+const val TEST_UPDATE_OPERATION_HOURS_OPEN = "10:00"
+const val TEST_UPDATE_OPERATION_HOURS_CLOSE = "13:59"
 
-fun createMockTestFoodSpot(id: Long = 0L) = MockTestFoodSpot(id)
+fun createMockTestFoodSpot(
+    id: Long = 0L,
+    name: String = TEST_FOOD_SPOT_NAME,
+    foodTruck: Boolean = TEST_FOOD_SPOT_FOOD_TRUCK,
+    open: Boolean = TEST_FOOD_SPOT_OPEN,
+    storeClosure: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
+    point: Point = TEST_FOOD_SPOT_POINT,
+    operationHours: MutableList<FoodSpotsOperationHours> = mutableListOf(createTestFoodOperationHours()),
+    foodCategories: MutableList<FoodSpotsFoodCategory> = createTestFoodSpotsFoodCategories(foodSpotsSize = 1),
+) = MockTestFoodSpot(id, name, foodTruck, open, storeClosure, point, operationHours, foodCategories)
 
 fun createMockTestFoodHistory(
     user: User = createTestUser(0L),
@@ -168,16 +184,13 @@ fun createTestFoodCategories(): List<FoodCategory> =
         createTestFoodCategory(4L, "술"),
     )
 
-fun createTestFoodSpotsFoodCategory(): List<FoodSpotsFoodCategory> =
-    listOf(
-        createTestFoodSpotsFoodCategory(1L, createTestFoodSpots(1L), createTestFoodCategory(1L)),
-        createTestFoodSpotsFoodCategory(2L, createTestFoodSpots(2L), createTestFoodCategory(2L)),
-        createTestFoodSpotsFoodCategory(3L, createTestFoodSpots(1L), createTestFoodCategory(2L)),
-        createTestFoodSpotsFoodCategory(4L, createTestFoodSpots(2L), createTestFoodCategory(3L)),
-        createTestFoodSpotsFoodCategory(5L, createTestFoodSpots(3L), createTestFoodCategory(1L)),
-        createTestFoodSpotsFoodCategory(6L, createTestFoodSpots(3L), createTestFoodCategory(2L)),
-        createTestFoodSpotsFoodCategory(7L, createTestFoodSpots(3L), createTestFoodCategory(3L)),
-    )
+fun createTestFoodSpotsFoodCategories(foodSpotsSize: Int = 3): MutableList<FoodSpotsFoodCategory> =
+    (1L..foodSpotsSize)
+        .flatMap { foodSpotsIndex ->
+            createTestFoodCategories().map { foodCategory ->
+                createTestFoodSpotsFoodCategory(createTestFoodSpots(foodSpotsIndex), foodCategory)
+            }
+        }.toMutableList()
 
 fun createFoodSpotsForDistance(): List<FoodSpots> =
     listOf(
@@ -321,3 +334,40 @@ fun createFoodSpotsSearchResponses(): FoodSpotsSearchResponses =
 
 fun createFoodCategoryResponse(foodCategory: FoodCategory = createTestFoodCategory()): FoodCategoryResponse =
     FoodCategoryResponse.of(foodCategory)
+
+fun createTestFoodSpotsUpdateRequest(
+    name: String = TEST_UPDATE_FOOD_SPOT_NAME,
+    longitude: Double = TEST_UPDATE_FOOD_SPOT_LONGITUDE,
+    latitude: Double = TEST_UPDATE_FOOD_SPOT_LATITUDE,
+    open: Boolean = TEST_FOOD_SPOT_OPEN,
+    closed: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
+    categories: Set<Long> = createTestFoodCategories().map { it.id }.toSet(),
+    operationHours: List<OperationHoursRequest> = listOf(createOperationHoursRequest()),
+): FoodSpotsUpdateRequest =
+    FoodSpotsUpdateRequest(
+        name,
+        longitude,
+        latitude,
+        open,
+        closed,
+        categories,
+        operationHours,
+    )
+
+// Entity 로부터 역으로 Request 를 만들어냅니다.
+// 원본 FoodSpots Entity 로부터 변경내용이 없는 FoodSpotsUpdateRequest 를 생성하여 유효하지 않은 FoodSpots Update 요청 테스트에 사용됩니다.
+fun createTestFoodSpotsUpdateRequestFromEntity(foodSpots: FoodSpots = createTestFoodSpots()): FoodSpotsUpdateRequest =
+    FoodSpotsUpdateRequest(
+        foodSpots.name,
+        foodSpots.point.x,
+        foodSpots.point.y,
+        foodSpots.open,
+        foodSpots.storeClosure,
+        foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet(),
+        createTestFoodSpotsOperationHoursRequestsFromEntities(foodSpots.operationHoursList),
+    )
+
+fun createTestFoodSpotsOperationHoursRequestsFromEntities(operationHours: List<FoodSpotsOperationHours>): List<OperationHoursRequest> =
+    operationHours.map {
+        createOperationHoursRequest(it.dayOfWeek, it.openingHours, it.closingHours)
+    }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -101,9 +101,9 @@ fun createTestFoodSpots(
 ) = FoodSpots(id, name, foodTruck, open, storeClosure, point, operationHours, foodCategories)
 
 fun createTestFoodSpotsFoodCategory(
-    id: Long = 0L,
     foodSpots: FoodSpots = createTestFoodSpots(),
     foodCategory: FoodCategory = createTestFoodCategory(),
+    id: Long = 0L,
 ) = FoodSpotsFoodCategory(id, foodSpots, foodCategory)
 
 fun createTestFoodCategory(
@@ -254,11 +254,6 @@ fun createOperationHoursRequest(
 ) = OperationHoursRequest(dayOfWeek, openingHours, closingHours)
 
 fun createTestFoodCategory(name: String = TEST_CATEGORY_NAME) = FoodCategory(name = name)
-
-fun createTestFoodSpotsFoodCategory(
-    foodSpots: FoodSpots = createTestFoodSpots(),
-    foodCategory: FoodCategory = createTestFoodCategory(),
-) = FoodSpotsFoodCategory(0L, foodSpots, foodCategory)
 
 fun createTestReportFoodCategory(
     foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory(),

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.foodSpots.presentation.api
 
+import TEST_FOOD_SPOT_ID
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -22,6 +23,7 @@ import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_NAME_TOO_LONG
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_INVALID_TIME_FORMAT
 import kr.weit.roadyfoody.foodSpots.fixture.createMockPhotoList
 import kr.weit.roadyfoody.foodSpots.fixture.createOperationHoursRequest
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportHistoriesResponse
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportRequest
 import kr.weit.roadyfoody.support.annotation.ControllerTest
@@ -31,6 +33,7 @@ import kr.weit.roadyfoody.support.utils.createMultipartFile
 import kr.weit.roadyfoody.support.utils.createTestImageFile
 import kr.weit.roadyfoody.support.utils.getWithAuth
 import kr.weit.roadyfoody.support.utils.multipartWithAuth
+import kr.weit.roadyfoody.support.utils.patchWithAuth
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.mock.web.MockMultipartFile
@@ -331,6 +334,118 @@ class FoodSpotsControllerTest(
                             .perform(
                                 getWithAuth("$requestPath/histories/$TEST_USER_ID")
                                     .param("lastId", "-1"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+            }
+
+            given("PATCH $requestPath/{foodSpotsId} Test") {
+                every { foodSpotsCommandService.doUpdateReport(any(), any(), any()) } just runs
+                `when`("정상적인 요청이 들어올 경우") {
+                    val request = createTestFoodSpotsUpdateRequest()
+                    then("해당 가게 정보를 수정한다.") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .contentType("application/json"),
+                            ).andExpect(status().isNoContent)
+                    }
+                }
+
+                `when`("상호명이 공백인 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(name = TEST_FOOD_SPOT_NAME_EMPTY)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("상호명에 허용되지 않은 특수문자가 포함된 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(name = TEST_FOOD_SPOT_NAME_INVALID_STR)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("상호명이 30자 초과인 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(name = TEST_FOOD_SPOT_NAME_TOO_LONG)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("경도가 범위를 벗어난 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(longitude = 190.0)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("위도가 범위를 벗어난 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(latitude = -190.0)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+
+                    `when`("운영시간 형식이 잘못된 경우") {
+                        val request =
+                            createTestFoodSpotsUpdateRequest(
+                                operationHours =
+                                    listOf(
+                                        createOperationHoursRequest(openingHours = TEST_INVALID_TIME_FORMAT),
+                                    ),
+                            )
+                        then("400을 반환") {
+                            mockMvc
+                                .perform(
+                                    patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                        .content(
+                                            objectMapper.writeValueAsString(request),
+                                        ).contentType("application/json"),
+                                ).andExpect(status().isBadRequest)
+                        }
+                    }
+                }
+
+                `when`("음식 카테고리가 없는 경우") {
+                    val request = createTestFoodSpotsUpdateRequest(categories = setOf())
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
                             ).andExpect(status().isBadRequest)
                     }
                 }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -350,7 +350,7 @@ class FoodSpotsControllerTest(
                                 patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .content(objectMapper.writeValueAsString(request))
                                     .contentType("application/json"),
-                            ).andExpect(status().isNoContent)
+                            ).andExpect(status().isCreated)
                     }
                 }
 

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -1,6 +1,7 @@
 package kr.weit.roadyfoody.foodSpots.presentation.api
 
 import TEST_FOOD_SPOT_ID
+import TEST_INVALID_FOOD_SPOT_ID
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
@@ -353,6 +354,17 @@ class FoodSpotsControllerTest(
                     }
                 }
 
+                `when`("음식점 ID가 양수가 아닌 경우") {
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_INVALID_FOOD_SPOT_ID")
+                                    .content(objectMapper.writeValueAsString(createTestFoodSpotsUpdateRequest()))
+                                    .contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
                 `when`("상호명이 공백인 경우") {
                     val request = createTestFoodSpotsUpdateRequest(name = TEST_FOOD_SPOT_NAME_EMPTY)
                     then("400을 반환") {
@@ -416,24 +428,24 @@ class FoodSpotsControllerTest(
                                     ).contentType("application/json"),
                             ).andExpect(status().isBadRequest)
                     }
+                }
 
-                    `when`("운영시간 형식이 잘못된 경우") {
-                        val request =
-                            createTestFoodSpotsUpdateRequest(
-                                operationHours =
-                                    listOf(
-                                        createOperationHoursRequest(openingHours = TEST_INVALID_TIME_FORMAT),
-                                    ),
-                            )
-                        then("400을 반환") {
-                            mockMvc
-                                .perform(
-                                    patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                        .content(
-                                            objectMapper.writeValueAsString(request),
-                                        ).contentType("application/json"),
-                                ).andExpect(status().isBadRequest)
-                        }
+                `when`("운영시간 형식이 잘못된 경우") {
+                    val request =
+                        createTestFoodSpotsUpdateRequest(
+                            operationHours =
+                                listOf(
+                                    createOperationHoursRequest(openingHours = TEST_INVALID_TIME_FORMAT),
+                                ),
+                        )
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .content(
+                                        objectMapper.writeValueAsString(request),
+                                    ).contentType("application/json"),
+                            ).andExpect(status().isBadRequest)
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -436,19 +436,6 @@ class FoodSpotsControllerTest(
                         }
                     }
                 }
-
-                `when`("음식 카테고리가 없는 경우") {
-                    val request = createTestFoodSpotsUpdateRequest(categories = setOf())
-                    then("400을 반환") {
-                        mockMvc
-                            .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
-                            ).andExpect(status().isBadRequest)
-                    }
-                }
             }
         },
     )

--- a/src/test/kotlin/kr/weit/roadyfoody/user/application/UserCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/application/UserCommandServiceTest.kt
@@ -17,6 +17,7 @@ class UserCommandServiceTest :
         val userRepository = mockk<UserRepository>()
         val userCommandService = UserCommandService(userRepository)
         val user = createTestUser()
+
         given("decreaseCoin 테스트") {
             val minusCoin = 100
             val expectedCoin = user.coin - minusCoin
@@ -39,16 +40,16 @@ class UserCommandServiceTest :
                     ex.message shouldBe ErrorCode.COIN_NOT_ENOUGH.errorMessage
                 }
             }
+        }
 
-            given("increaseCoin 테스트") {
-                val plusCoin = 100
-                val expectedCoin = user.coin + plusCoin
-                every { userRepository.findById(TEST_USER_ID) } returns Optional.of(user)
-                `when`("코인을 증가시키면") {
-                    userCommandService.increaseCoin(user.id, plusCoin)
-                    then("코인이 증가한다.") {
-                        user.coin shouldBe expectedCoin
-                    }
+        given("increaseCoin 테스트") {
+            val plusCoin = 100
+            val expectedCoin = user.coin + plusCoin
+            every { userRepository.findById(TEST_USER_ID) } returns Optional.of(user)
+            `when`("코인을 증가시키면") {
+                userCommandService.increaseCoin(user.id, plusCoin)
+                then("코인이 증가한다.") {
+                    user.coin shouldBe expectedCoin
                 }
             }
         }


### PR DESCRIPTION
### 개요
음식점 정보를 수정하기 위한 리포트 관련  API 를 작성합니다.
기능을 만들기 앞서 리포트 저장 부분이 중복될 것 같아 음식점 저장, 리포트 저장 로직을 메소드로 추출하였습니다.

### 변경사항
- 기존 로직 메소드로 추출 (음식점 저장, 리포트 저장 )
- doUpdateReport 기능 생성 및 테스트 작성
- 음식점 정보 수정 API 및 테스트 작성


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-119) 


### 리뷰어에게 하고 싶은 말
모든 피드백 감사히 잘 받겠습니다!