### PR TITLE
ROFO-109 로그인 유저 정보 조회 API 작성

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -16,7 +16,7 @@ import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
 import kr.weit.roadyfoody.foodSpots.repository.getFoodCategories
 import kr.weit.roadyfoody.global.service.ImageService
 import kr.weit.roadyfoody.mission.domain.RewardPoint
-import kr.weit.roadyfoody.user.application.UserCommandService
+import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
@@ -8,5 +8,6 @@ object SwaggerTag {
     const val FOOD_SPOTS: String = "D. 음식점 리포트 API"
     const val REVIEW: String = "E. 리뷰 API"
     const val FOOD_CATEGORIES: String = "F. 음식점 카테고리 API"
+    const val USER: String = "G. 유저 API"
     const val ADMIN: String = "Z. 관리자 API"
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/foodSpots/application/service/FoodSpotsSearchService.kt
@@ -6,7 +6,7 @@ import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsQueryService
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchCondition
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponses
-import kr.weit.roadyfoody.user.application.UserCommandService
+import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.stereotype.Service
 import kotlin.math.pow

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
@@ -1,0 +1,20 @@
+package kr.weit.roadyfoody.user.application.dto
+
+data class UserInfoResponse(
+    val nickname: String,
+    val profileImageUrl: String?,
+    val coin: Int,
+) {
+    companion object {
+        fun of(
+            nickname: String,
+            profileImageUrl: String?,
+            coin: Int,
+        ): UserInfoResponse =
+            UserInfoResponse(
+                nickname = nickname,
+                profileImageUrl = profileImageUrl,
+                coin = coin,
+            )
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
@@ -1,4 +1,4 @@
-package kr.weit.roadyfoody.user.application
+package kr.weit.roadyfoody.user.application.service
 
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
@@ -1,0 +1,25 @@
+package kr.weit.roadyfoody.user.application.service
+
+import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.repository.UserRepository
+import kr.weit.roadyfoody.user.repository.getByUserId
+import org.springframework.stereotype.Service
+
+@Service
+class UserQueryService(
+    private val userRepository: UserRepository,
+    private val imageService: ImageService,
+) {
+    fun getUserInfo(user: User): UserInfoResponse {
+        val user = userRepository.getByUserId(user.id)
+        val profileImageUrl = user.profile.profileImageName?.let { imageService.getDownloadUrl(it) }
+
+        return UserInfoResponse.of(
+            user.profile.nickname,
+            profileImageUrl,
+            user.coin,
+        )
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
@@ -1,0 +1,21 @@
+package kr.weit.roadyfoody.user.presentation.api
+
+import kr.weit.roadyfoody.auth.security.LoginUser
+import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+import kr.weit.roadyfoody.user.application.service.UserQueryService
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.presentation.spec.UserControllerSpec
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserController(
+    private val userQueryService: UserQueryService,
+) : UserControllerSpec {
+    @GetMapping("/me")
+    override fun getLoginUserInfo(
+        @LoginUser user: User,
+    ): UserInfoResponse = userQueryService.getUserInfo(user)
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
@@ -1,0 +1,33 @@
+package kr.weit.roadyfoody.user.presentation.spec
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
+import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+import kr.weit.roadyfoody.user.domain.User
+import org.springframework.http.MediaType
+
+@Tag(name = SwaggerTag.USER)
+interface UserControllerSpec {
+    @Operation(
+        summary = "로그인 유저 정보 조회 API",
+        description = "로그인한 유저 정보(닉네임, 프로필 사진 URL, 보유 코인) 를 조회합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "로그인 유저 정보 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema =
+                            Schema(implementation = UserInfoResponse::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getLoginUserInfo(user: User): UserInfoResponse
+}

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -34,7 +34,7 @@ import kr.weit.roadyfoody.foodSpots.repository.ReportFoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
 import kr.weit.roadyfoody.global.service.ImageService
 import kr.weit.roadyfoody.support.utils.ImageFormat
-import kr.weit.roadyfoody.user.application.UserCommandService
+import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository

--- a/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/application/FoodSpotsSearchServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/foodSpots/application/FoodSpotsSearchServiceTest.kt
@@ -9,7 +9,7 @@ import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsQueryService
 import kr.weit.roadyfoody.foodSpots.fixture.createFoodSpotsSearchResponses
 import kr.weit.roadyfoody.search.foodSpots.application.service.FoodSpotsSearchService
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchCondition
-import kr.weit.roadyfoody.user.application.UserCommandService
+import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.fixture.createTestUser
 
 class FoodSpotsSearchServiceTest :

--- a/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandServiceTest.kt
@@ -1,4 +1,4 @@
-package kr.weit.roadyfoody.user.application
+package kr.weit.roadyfoody.user.application.service
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec

--- a/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryServiceTest.kt
@@ -1,0 +1,47 @@
+package kr.weit.roadyfoody.user.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.user.fixture.TEST_USER_PROFILE_IMAGE_URL
+import kr.weit.roadyfoody.user.fixture.createTestUser
+import kr.weit.roadyfoody.user.repository.UserRepository
+import java.util.Optional
+
+class UserQueryServiceTest :
+    BehaviorSpec({
+        val userRepository = mockk<UserRepository>()
+        val imageService = mockk<ImageService>()
+        val userQueryService = UserQueryService(userRepository, imageService)
+
+        afterEach { clearAllMocks() }
+
+        given("getUserInfo 테스트") {
+            `when`("프로필사진이 존재하는 유저의 경우") {
+                val user = createTestUser()
+                every { userRepository.findById(any<Long>()) } returns Optional.of(user)
+                every { imageService.getDownloadUrl(any<String>()) } returns TEST_USER_PROFILE_IMAGE_URL
+                then("프로필사진 URL 이 존재하는 응답을 반환한다.") {
+                    val userInfoResponse = userQueryService.getUserInfo(user)
+                    userInfoResponse.profileImageUrl shouldBe TEST_USER_PROFILE_IMAGE_URL
+                    verify(exactly = 1) { imageService.getDownloadUrl(any<String>()) }
+                }
+            }
+
+            `when`("프로필사진이 존재하지 않는 유저의 경우") {
+                val user = createTestUser(profileImageName = null)
+                every { userRepository.findById(any<Long>()) } returns Optional.of(user)
+                every { imageService.getDownloadUrl(any<String>()) } returns TEST_USER_PROFILE_IMAGE_URL
+                then("프로필사진 URL 이 null 인 응답을 반환한다.") {
+                    val userInfoResponse = userQueryService.getUserInfo(user)
+                    userInfoResponse.profileImageUrl.shouldBeNull()
+                    verify(exactly = 0) { imageService.getDownloadUrl(any<String>()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
@@ -1,0 +1,13 @@
+package kr.weit.roadyfoody.user.fixture
+
+import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+
+fun createTestUserInfoResponse(
+    nickname: String = TEST_USER_NICKNAME,
+    profileImageUrl: String = TEST_USER_PROFILE_IMAGE_URL,
+    coin: Int = TEST_USER_COIN,
+) = UserInfoResponse(
+    nickname = nickname,
+    profileImageUrl = profileImageUrl,
+    coin = coin,
+)

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
@@ -15,18 +15,21 @@ val TEST_SOCIAL_LOGIN_TYPE = SocialLoginType.KAKAO
 val TEST_USER_SOCIAL_ID = "$TEST_SOCIAL_LOGIN_TYPE $TEST_SOCIAL_ID"
 const val TEST_USER_NICKNAME = "existentNick"
 const val TEST_USER_PROFILE_IMAGE_NAME = "test_image_name"
+const val TEST_USER_PROFILE_IMAGE_URL = "test/image/url"
+const val TEST_USER_COIN = 500
 
 fun createTestUser(
     id: Long = TEST_USER_ID,
     nickname: String = TEST_USER_NICKNAME,
     socialId: String = TEST_USER_SOCIAL_ID,
-    coin: Int = 500,
+    profileImageName: String? = "${TEST_USER_PROFILE_IMAGE_NAME}_$id",
+    coin: Int = TEST_USER_COIN,
 ) = User(
     id,
     socialId,
     Profile(
         nickname,
-        "${TEST_USER_PROFILE_IMAGE_NAME}_$id",
+        profileImageName,
     ),
     coin,
 )

--- a/src/test/kotlin/kr/weit/roadyfoody/user/presentation/api/UserControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/presentation/api/UserControllerTest.kt
@@ -1,0 +1,42 @@
+package kr.weit.roadyfoody.user.presentation.api
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import kr.weit.roadyfoody.support.annotation.ControllerTest
+import kr.weit.roadyfoody.support.utils.getWithAuth
+import kr.weit.roadyfoody.user.application.service.UserQueryService
+import kr.weit.roadyfoody.user.fixture.createTestUserInfoResponse
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ControllerTest
+@WebMvcTest(UserController::class)
+class UserControllerTest(
+    @MockkBean private val userQueryService: UserQueryService,
+    private val mockMvc: MockMvc,
+) : BehaviorSpec({
+        val requestPath = "/api/v1/users"
+
+        given("GET $requestPath/me 테스트") {
+            `when`("로그인한 유저의 정보를 조회하는 경우") {
+                every { userQueryService.getUserInfo(any()) } returns createTestUserInfoResponse()
+                then("로그인한 유저의 정보를 반환한다.") {
+                    mockMvc
+                        .perform(getWithAuth("$requestPath/me"))
+                        .andExpect(status().isOk)
+                }
+            }
+
+            `when`("로그인 정보 없이 유저의 정보를 조회하는 경우") {
+                every { userQueryService.getUserInfo(any()) } returns createTestUserInfoResponse()
+                then("로그인한 유저의 정보를 반환한다.") {
+                    mockMvc
+                        .perform(get("$requestPath/me"))
+                        .andExpect(status().isUnauthorized)
+                }
+            }
+        }
+    })


### PR DESCRIPTION
### 개요
마이페이지 등에서 사용하기 위해 로그인 유저 정보 조회 API 를 작성해야합니다.

### 변경사항
- UserCommandService 패키지 이동 (service 패키지 내부로)
- UserQueryService 및 테스트 작성
- 로그인 유저 정보 조회 API 작성


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-109) 


### 리뷰어에게 하고 싶은 말
**토큰으로 데이터를 저장해 전달하는 방식**과 **API 로 요청하는 방식** 두 가지 중 고민을 했습니다. (좋은 주제를 주셔서 감사합니다.)
성능적으로 큰 차이는 없을 듯 하여 클라이언트 개발자 분께 어느 방식이 사용할 때 편할지 여쭤봤습니다.

결론적으로 **API 요청 방식**을 택했습니다. 
> "토큰 방식의 경우 나중에 유저 정보 수정 기능이 생기게되면 관리가 복잡해질 수 있다." 라는 의견을 주셨습니다.

모든 피드백 감사히 잘 받겠습니다!