### PR TITLE
ROFO-142 주소 API 오류 수정

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/search/address/dto/Point2AddressResponse.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/address/dto/Point2AddressResponse.kt
@@ -4,8 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "도로명 주소 검색 결과")
 data class Point2AddressResponse(
-    @Schema(description = "도로명 주소", example = "경기도 안성시 죽산면 죽산초교길 69-4")
-    val roadAddressName: String,
+    @Schema(description = "도로명 주소(optional)", example = "경기도 안성시 죽산면 죽산초교길 69-4")
+    val roadAddressName: String?,
     @Schema(description = "지번 주소", example = "경기 안성시 죽산면 죽산리 343-1")
     val addressName: String,
     @Schema(description = "위도", example = "37.0789561558879")
@@ -21,7 +21,7 @@ data class Point2AddressResponse(
         ): Point2AddressResponse =
             Point2AddressResponse(
                 addressName = document.address.addressName,
-                roadAddressName = document.roadAddress.addressName,
+                roadAddressName = document.roadAddress?.addressName,
                 latitude = latitude,
                 longitude = longitude,
             )

--- a/src/main/kotlin/kr/weit/roadyfoody/search/address/dto/Point2AddressWrapper.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/search/address/dto/Point2AddressWrapper.kt
@@ -31,7 +31,7 @@ data class Address(
 )
 
 data class Point2AddressData(
-    @JsonProperty("road_address") val roadAddress: RoadAddress,
+    @JsonProperty("road_address") val roadAddress: RoadAddress?,
     @JsonProperty("address") val address: Address,
 )
 

--- a/src/test/kotlin/kr/weit/roadyfoody/search/address/application/service/AddressSearchServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/address/application/service/AddressSearchServiceTest.kt
@@ -95,6 +95,24 @@ class AddressSearchServiceTest :
                 }
             }
 
+            `when`("도로명 주소가 null인 경우") {
+                val point2AddressWrapper = AddressFixture.loadPoint2AddressWithoutRoadAddressResponse()
+
+                every {
+                    kakaoPointClientInterface.searchPointToAddress(
+                        "127.0",
+                        "37.0",
+                    )
+                } returns point2AddressWrapper
+
+                val result = addressService.searchPoint2Address(127.0, 37.0)
+
+                then("주소를 반환한다.") {
+                    result.roadAddressName shouldBe null
+                    result.addressName shouldBe "경기 안성시 죽산면 죽산리 343-1"
+                }
+            }
+
             `when`("주소를 찾을 수 없는 경우") {
                 every {
                     kakaoPointClientInterface.searchPointToAddress(

--- a/src/test/kotlin/kr/weit/roadyfoody/search/address/fixture/AddressFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/search/address/fixture/AddressFixture.kt
@@ -14,6 +14,7 @@ object AddressFixture {
     private const val ADDRESS_RESPONSE_SIZE_10 = "payload/address-search-response.json"
     private const val ADDRESS_RESPONSE_SIZE_0 = "payload/address-search-response-size-0.json"
     private const val POINT_TO_ADDRESS_RESPONSE = "payload/point-to-address-response.json"
+    private const val POINT_TO_ADDRESS_WITHOUT_ROAD_ADDRESS_RESPONSE = "payload/point-to-address-without-road-address-response.json"
 
     private fun loadAddressJson(resourcePath: String): AddressResponseWrapper {
         val resource = ClassPathResource(resourcePath)
@@ -30,6 +31,9 @@ object AddressFixture {
     fun loadAddressResponseSize0(): AddressResponseWrapper = loadAddressJson(ADDRESS_RESPONSE_SIZE_0)
 
     fun loadPoint2AddressResponse(): Point2AddressWrapper = loadPointToAddressJson(POINT_TO_ADDRESS_RESPONSE)
+
+    fun loadPoint2AddressWithoutRoadAddressResponse(): Point2AddressWrapper =
+        loadPointToAddressJson(POINT_TO_ADDRESS_WITHOUT_ROAD_ADDRESS_RESPONSE)
 
     fun createSearchResponses(): AddressSearchResponses =
         AddressSearchResponses(

--- a/src/test/resources/payload/point-to-address-without-road-address-response.json
+++ b/src/test/resources/payload/point-to-address-without-road-address-response.json
@@ -1,0 +1,18 @@
+{
+  "meta": {
+    "total_count": 1
+  },
+  "documents": [
+    {
+      "address": {
+        "address_name": "경기 안성시 죽산면 죽산리 343-1",
+        "region_1depth_name": "경기",
+        "region_2depth_name": "안성시",
+        "region_3depth_name": "죽산면 죽산리",
+        "mountain_yn": "N",
+        "main_address_no": "343",
+        "sub_address_no": "1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### 개요
- 카카오 지도 API에서 좌표로 주소 검색시 도로명 주소는 항상 존재하는게 아닌데 필수값으로 선언되어있었다

### 변경사항
- 도로명 주소 항목을 nullable로 선언

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-142) 


### 리뷰어에게 하고 싶은 말
- 공식문서에도 제대로 안써있어서 도로명 주소가 nullable일줄 저도 몰랐네요 ㅋㅋㅋㅋ
