### PR TITLE
ROFO-134 리포트 생성 일일 제한 로직 추가

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -19,7 +19,6 @@ enum class ErrorCode(
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, -10008, "Payload too large"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, -10009, "Not found user"),
     NOT_FOUND_TERM(HttpStatus.NOT_FOUND, -10010, "Not found term"),
-    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, -10011, "Too many requests"),
     REDISSON_LOCK_TOO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, -10012, "동시에 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요"),
     REDISSON_LOCK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, -10013, "레디스 락을 사용할 수 없습니다."),
     BAD_REDISSON_IDENTIFIER(HttpStatus.INTERNAL_SERVER_ERROR, -10014, "레디스 락 식별자가 잘못되었습니다."),
@@ -78,6 +77,7 @@ enum class ErrorCode(
     NOT_FOUND_FOOD_CATEGORY(HttpStatus.NOT_FOUND, -13001, "해당 카테고리가 존재하지 않습니다."),
     NOT_FOUND_FOOD_SPOTS_HISTORIES(HttpStatus.NOT_FOUND, -13002, "해당 음식점 리포트가 존재하지 않습니다."),
     NOT_FOOD_SPOTS_HISTORIES_OWNER(HttpStatus.FORBIDDEN, -13003, "해당 음식점 리포트의 소유자가 아닙니다."),
+    TOO_MANY_REPORT_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, -13005, "일일 리포트 생성 횟수를 초과하였습니다."),
 
     // Review API error 14000대
     FOOD_SPOT_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -14000, "음식점 ID는 양수여야 합니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -19,6 +19,7 @@ enum class ErrorCode(
     PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, -10008, "Payload too large"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, -10009, "Not found user"),
     NOT_FOUND_TERM(HttpStatus.NOT_FOUND, -10010, "Not found term"),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, -10011, "Too many requests"),
     REDISSON_LOCK_TOO_MANY_REQUEST(HttpStatus.TOO_MANY_REQUESTS, -10012, "동시에 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요"),
     REDISSON_LOCK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, -10013, "레디스 락을 사용할 수 없습니다."),
     BAD_REDISSON_IDENTIFIER(HttpStatus.INTERNAL_SERVER_ERROR, -10014, "레디스 락 식별자가 잘못되었습니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -5,6 +5,7 @@ import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
+import kr.weit.roadyfoody.foodSpots.application.service.event.ReportErrorCompensatingTxSync
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
@@ -13,6 +14,7 @@ import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsPhoto
 import kr.weit.roadyfoody.foodSpots.domain.ReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.exception.NotFoodSpotsHistoriesOwnerException
+import kr.weit.roadyfoody.foodSpots.exception.TooManyReportRequestException
 import kr.weit.roadyfoody.foodSpots.repository.FoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSportsOperationHoursRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsFoodCategoryRepository
@@ -30,13 +32,20 @@ import kr.weit.roadyfoody.mission.domain.RewardPoint
 import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
 import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.multipart.MultipartFile
 import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 
 @Service
 class FoodSpotsCommandService(
@@ -53,11 +62,15 @@ class FoodSpotsCommandService(
     private val userCommandService: UserCommandService,
     private val entityManager: EntityManager,
     private val redissonClient: RedissonClient,
+    private val redisTemplate: RedisTemplate<String, String>,
 ) {
     companion object {
         private const val FOOD_SPOTS_OPEN_SCHEDULER_LOCK = "foodSpotsOpenSchedulerLock"
         private val FOOD_SPOTS_OPEN_SCHEDULER_LOCK_DURATION: Duration =
             Duration.ofHours(23) + Duration.ofMinutes(50)
+
+        private const val FOOD_SPOTS_REPORT_LIMIT_PREFIX = "rofo:report-request-limit:"
+        private const val FOOD_SPOTS_REPORT_LIMIT_COUNT = 5
     }
 
     @Transactional
@@ -66,6 +79,16 @@ class FoodSpotsCommandService(
         reportRequest: ReportRequest,
         photos: List<MultipartFile>?,
     ) {
+        val today = LocalDate.now()
+        val key = "$FOOD_SPOTS_REPORT_LIMIT_PREFIX${user.id}:$today"
+        check(canGenerateReport(key, today)) {
+            throw TooManyReportRequestException()
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            ReportErrorCompensatingTxSync(key, redisTemplate),
+        )
+
         val foodSpots = reportRequest.toFoodSpotsEntity()
         storeFoodSpots(
             foodSpots,
@@ -122,6 +145,16 @@ class FoodSpotsCommandService(
         foodSpotsId: Long,
         request: FoodSpotsUpdateRequest,
     ) {
+        val today = LocalDate.now()
+        val key = "$FOOD_SPOTS_REPORT_LIMIT_PREFIX${user.id}:$today"
+        check(canGenerateReport(key, today)) {
+            throw TooManyReportRequestException()
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            ReportErrorCompensatingTxSync(key, redisTemplate),
+        )
+
         val foodSpots = foodSpotsRepository.getByFoodSpotsId(foodSpotsId)
 
         val changed =
@@ -245,6 +278,28 @@ class FoodSpotsCommandService(
 
         val changed = foodSpotsOperationHoursToRemove.isNotEmpty() || foodSpotsOperationHoursToAdd.isNotEmpty()
         return changed
+    }
+
+    private fun canGenerateReport(
+        key: String,
+        today: LocalDate,
+    ): Boolean {
+        // redis 내에 존재하지 않을 시 1L 반환
+        val count = redisTemplate.opsForValue().increment(key)!!
+
+        if (count > FOOD_SPOTS_REPORT_LIMIT_COUNT) {
+            return false
+        }
+        if (count == 1L) {
+            val secondsUntilDue =
+                ChronoUnit.SECONDS
+                    .between(
+                        LocalDateTime.now(),
+                        LocalDateTime.of(today.plusDays(1), LocalTime.MIDNIGHT),
+                    )
+            redisTemplate.expire(key, secondsUntilDue, TimeUnit.SECONDS)
+        }
+        return true
     }
 
     @Transactional

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/event/ReportErrorCompensatingTxSync.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/event/ReportErrorCompensatingTxSync.kt
@@ -1,0 +1,16 @@
+package kr.weit.roadyfoody.foodSpots.application.service.event
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.transaction.reactive.TransactionSynchronization.STATUS_ROLLED_BACK
+import org.springframework.transaction.support.TransactionSynchronization
+
+class ReportErrorCompensatingTxSync(
+    private val key: String,
+    private val redisTemplate: RedisTemplate<String, String>,
+) : TransactionSynchronization {
+    override fun afterCompletion(status: Int) {
+        if (status == STATUS_ROLLED_BACK) {
+            redisTemplate.opsForValue().decrement(key)
+        }
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
@@ -44,7 +44,9 @@ class FoodSpots(
     val foodCategoryList: MutableList<FoodSpotsFoodCategory>,
 ) : BaseModifiableEntity() {
     init {
-        require(FOOD_SPOTS_NAME_REGEX.matches(name)) { FOOD_SPOTS_NAME_REGEX_DESC }
+        name?.let {
+            require(FOOD_SPOTS_NAME_REGEX.matches(name)) { FOOD_SPOTS_NAME_REGEX_DESC }
+        }
     }
 
     companion object {

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpots.kt
@@ -10,8 +10,6 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
 import kr.weit.roadyfoody.common.domain.BaseModifiableEntity
-import kr.weit.roadyfoody.foodSpots.utils.FOOD_SPOTS_NAME_REGEX
-import kr.weit.roadyfoody.foodSpots.utils.FOOD_SPOTS_NAME_REGEX_DESC
 import kr.weit.roadyfoody.global.utils.CoordinateUtils.Companion.createCoordinate
 import org.locationtech.jts.geom.Point
 
@@ -43,12 +41,6 @@ class FoodSpots(
     @OneToMany(mappedBy = "foodSpots")
     val foodCategoryList: MutableList<FoodSpotsFoodCategory>,
 ) : BaseModifiableEntity() {
-    init {
-        name?.let {
-            require(FOOD_SPOTS_NAME_REGEX.matches(name)) { FOOD_SPOTS_NAME_REGEX_DESC }
-        }
-    }
-
     companion object {
         // SRID_WGS84: WGS84 좌표계
         const val SRID_WGS84 = 4326

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/TooManyReportRequestException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/TooManyReportRequestException.kt
@@ -4,5 +4,5 @@ import kr.weit.roadyfoody.common.exception.BaseException
 import kr.weit.roadyfoody.common.exception.ErrorCode
 
 class TooManyReportRequestException(
-    message: String = ErrorCode.TOO_MANY_REQUESTS.errorMessage,
-) : BaseException(ErrorCode.TOO_MANY_REQUESTS, message)
+    message: String = ErrorCode.TOO_MANY_REPORT_REQUESTS.errorMessage,
+) : BaseException(ErrorCode.TOO_MANY_REPORT_REQUESTS, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/TooManyReportRequestException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/TooManyReportRequestException.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.foodSpots.exception
+
+import kr.weit.roadyfoody.common.exception.BaseException
+import kr.weit.roadyfoody.common.exception.ErrorCode
+
+class TooManyReportRequestException(
+    message: String = ErrorCode.TOO_MANY_REQUESTS.errorMessage,
+) : BaseException(ErrorCode.TOO_MANY_REQUESTS, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -44,7 +44,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.INVALID_IMAGE_TYPE,
             ErrorCode.IMAGES_SIZE_TOO_LARGE,
             ErrorCode.NOT_FOUND_FOOD_CATEGORY,
-            ErrorCode.TOO_MANY_REQUESTS,
+            ErrorCode.TOO_MANY_REPORT_REQUESTS,
         ],
     )
     fun createReport(
@@ -81,7 +81,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.NOT_FOUND_FOOD_CATEGORY,
             ErrorCode.INVALID_CHANGE_VALUE,
             ErrorCode.NON_POSITIVE_FOOD_SPOT_ID,
-            ErrorCode.TOO_MANY_REQUESTS,
+            ErrorCode.TOO_MANY_REPORT_REQUESTS,
         ],
     )
     fun updateFoodSpots(

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -44,6 +44,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.INVALID_IMAGE_TYPE,
             ErrorCode.IMAGES_SIZE_TOO_LARGE,
             ErrorCode.NOT_FOUND_FOOD_CATEGORY,
+            ErrorCode.TOO_MANY_REQUESTS,
         ],
     )
     fun createReport(
@@ -80,6 +81,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.NOT_FOUND_FOOD_CATEGORY,
             ErrorCode.INVALID_CHANGE_VALUE,
             ErrorCode.NON_POSITIVE_FOOD_SPOT_ID,
+            ErrorCode.TOO_MANY_REQUESTS,
         ],
     )
     fun updateFoodSpots(

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
@@ -88,15 +88,13 @@ class FoodSpotsCommandServiceIntegrationTest(
                             val jobs =
                                 List(10) {
                                     launch {
-                                        try {
+                                        runCatching {
                                             foodSpotsCommandService.createReport(
                                                 user,
-                                                createTestReportRequest(foodCategories = categories.map { it.id }.toSet()),
+                                                createTestReportRequest(),
                                                 null,
                                             )
-                                        } catch (e: Throwable) {
-                                            exceptions.add(e)
-                                        }
+                                        }.onFailure { exceptions.add(it) }
                                     }
                                 }
                             jobs.joinAll()
@@ -115,13 +113,12 @@ class FoodSpotsCommandServiceIntegrationTest(
                     every { redisTemplate.opsForValue() } returns ops
                     then("그 값만큼 감소한다.") {
                         repeat(5) {
-                            try {
+                            runCatching {
                                 foodSpotsCommandService.createReport(
                                     user,
                                     createTestReportRequest(foodCategories = categories.map { it.id }.toSet()),
                                     null,
                                 )
-                            } catch (ignored: Throwable) {
                             }
                         }
                         verify(exactly = 5) { ops.decrement(any()) }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
@@ -2,17 +2,44 @@ package kr.weit.roadyfoody.foodSpots.application.service
 
 import com.ninjasquad.springmockk.SpykBean
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.should
+import io.kotest.matchers.types.beInstanceOf
+import io.mockk.every
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kr.weit.roadyfoody.foodSpots.domain.FoodCategory
+import kr.weit.roadyfoody.foodSpots.exception.TooManyReportRequestException
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodCategories
+import kr.weit.roadyfoody.foodSpots.fixture.createTestReportRequest
+import kr.weit.roadyfoody.foodSpots.repository.FoodCategoryRepository
+import kr.weit.roadyfoody.foodSpots.repository.FoodSportsOperationHoursRepository
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsFoodCategoryRepository
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsRepository
+import kr.weit.roadyfoody.foodSpots.repository.ReportFoodCategoryRepository
+import kr.weit.roadyfoody.foodSpots.repository.ReportOperationHoursRepository
 import kr.weit.roadyfoody.support.annotation.ServiceIntegrateTest
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.fixture.createTestUser
+import kr.weit.roadyfoody.user.repository.UserRepository
+import org.springframework.data.redis.core.RedisTemplate
 
 @ServiceIntegrateTest
 class FoodSpotsCommandServiceIntegrationTest(
     @SpykBean private val foodSpotsRepository: FoodSpotsRepository,
+    private val foodSpotsCategoryRepository: FoodSpotsFoodCategoryRepository,
+    private val foodSportsOperationHoursRepository: FoodSportsOperationHoursRepository,
     private val foodSpotsCommandService: FoodSpotsCommandService,
+    private val userRepository: UserRepository,
+    private val categoryRepository: FoodCategoryRepository,
+    private val foodSpotsHistoryRepository: FoodSpotsHistoryRepository,
+    private val reportFoodCategoryRepository: ReportFoodCategoryRepository,
+    private val reportOperationHoursRepository: ReportOperationHoursRepository,
+    @SpykBean private val redisTemplate: RedisTemplate<String, String>,
 ) : BehaviorSpec(
         {
 
@@ -31,6 +58,73 @@ class FoodSpotsCommandServiceIntegrationTest(
                             jobs.joinAll()
                             verify(exactly = 1) { foodSpotsRepository.updateOpeningStatus() }
                         }
+                    }
+                }
+            }
+
+            given("리포트 생성 시") {
+                lateinit var user: User
+                lateinit var categories: List<FoodCategory>
+                beforeEach {
+                    user = userRepository.save(createTestUser())
+                    categories = categoryRepository.saveAll(createTestFoodCategories())
+                }
+                afterEach {
+                    reportFoodCategoryRepository.deleteAll()
+                    reportOperationHoursRepository.deleteAll()
+                    foodSpotsHistoryRepository.deleteAll()
+                    foodSpotsCategoryRepository.deleteAll()
+                    foodSportsOperationHoursRepository.deleteAll()
+                    foodSpotsRepository.deleteAll()
+                    userRepository.delete(user)
+                    categoryRepository.deleteAll(categories)
+                    val keys = redisTemplate.keys("*")
+                    redisTemplate.delete(keys)
+                }
+                `when`("일일 요청 횟수 5를 초과하는 경우") {
+                    then("TooManyReportRequestException 예외가 발생해야 한다.") {
+                        runBlocking {
+                            val exceptions = mutableListOf<Throwable>()
+                            val jobs =
+                                List(10) {
+                                    launch {
+                                        try {
+                                            foodSpotsCommandService.createReport(
+                                                user,
+                                                createTestReportRequest(foodCategories = categories.map { it.id }.toSet()),
+                                                null,
+                                            )
+                                        } catch (e: Throwable) {
+                                            exceptions.add(e)
+                                        }
+                                    }
+                                }
+                            jobs.joinAll()
+
+                            exceptions.shouldNotBeEmpty()
+                            exceptions.forEach {
+                                it should beInstanceOf<TooManyReportRequestException>()
+                            }
+                        }
+                    }
+                }
+
+                `when`("redis 상 요청 횟수가 증가한 뒤 오류가 발생한다면") {
+                    every { foodSpotsRepository.save(any()) } throws RuntimeException()
+                    val ops = spyk(redisTemplate.opsForValue())
+                    every { redisTemplate.opsForValue() } returns ops
+                    then("그 값만큼 감소한다.") {
+                        repeat(5) {
+                            try {
+                                foodSpotsCommandService.createReport(
+                                    user,
+                                    createTestReportRequest(foodCategories = categories.map { it.id }.toSet()),
+                                    null,
+                                )
+                            } catch (ignored: Throwable) {
+                            }
+                        }
+                        verify(exactly = 5) { ops.decrement(any()) }
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceIntegrationTest.kt
@@ -88,13 +88,15 @@ class FoodSpotsCommandServiceIntegrationTest(
                             val jobs =
                                 List(10) {
                                     launch {
-                                        runCatching {
+                                        try {
                                             foodSpotsCommandService.createReport(
                                                 user,
                                                 createTestReportRequest(),
                                                 null,
                                             )
-                                        }.onFailure { exceptions.add(it) }
+                                        } catch (ex: Throwable) {
+                                            exceptions.add(ex)
+                                        }
                                     }
                                 }
                             jobs.joinAll()


### PR DESCRIPTION
### 개요
리포트 생성 어뷰징 방지를 위해 일일 제한 로직을 추가합니다.

### 변경사항
- TooManyReportRequestException 작성
- 음식점 이름 유효성 검사 시 null safe 로직 추가
- 리포트 생성 일일 요청 제한 로직 추가 및 예외 시 보상 로직 작성
- 리포트 생성 API ErrorExample 추가

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-134) 


### 리뷰어에게 하고 싶은 말
몇 가지 고민한 부분이 있습니다.
- RDB vs Redis
    - RDB 
        - 장점
            - 데이터 유실의 문제를 예방할 수 있습니다. 
            - 운영에 안정적입니다.
            - 스프링 환경에서 트랜잭션을 이용하기 편리합니다.
        - 단점 
            - 추가적인 테이블이 필요합니다.
            - I/O 에 의한 비용
    -  Redis
        - 장점 
            - 추가적인 테이블이 필요하지 않습니다.
            - 인메모리 DB 로 빠릅니다.
            - key / value 구조로 빠르고 쉽게 사용할 수 있습니다.
        - 단점  
            - 운영을 고려하면 신경써야할 점이 많습니다.
            - 트랜잭션의 도움을 받기 힘듭니다. 따라서 보상 로직을 고려해야 합니다.

저는 결론적으로 **Redis 만으로 구현**했습니다.
참고한 [책](https://m.yes24.com/Goods/Detail/102819435)에서 Redis 를 가지고 처리율 제한 장치를 만드는 것에서 영감을 받았습니다.
그리고 구현에 있어 Redis 를 이용하는게 좀 더 편하다 느꼈습니다.

만약 **운영단계에서 Redis 장애에 대한 대책**을 물어보신다면 Redis 를 복제해 여러 개로
운영한다던가 Redis 백업 자료로 대처한다던가 하는 수를 생각하고 있습니다.
RDB 로도 기능을 구현해 백업을 하는 것도 좋아보이네요. 
그래도 현재 기능개발단계에선 Redis 만으로도 괜찮지 않을까 생각했습니다.

외부 Redis 를 사용하는 만큼 예외 발생 시의 보상로직도 고려해야했습니다.

여기선 `TransactionSynchronizationManager.registerSynchronization()` 을 통해
트랜잭션 롤백 시의 동작을 정의했습니다.

`TransactionalEventListener` 를 통해서도 구현할 수 있지만 별도로 `applicationEventPublisher` 를 주입받고 싶지 않아 정적 요소를 사용했습니다.

---

통합테스트 시 foodSpots 를 전체조회 시
non-null 프로퍼티인 name 에 순간적으로 null 값이
들어오는 경우가 있었습니다.
그리고 FoodSpots.init() 내부의 유효성 검사 단계에서
npe 가 발생했습니다.
이를 피하기 위해 null safe 로직을 추가했습니다.

뭔가 문제인지 디버깅을 좀 해보려했는데 생각보다 잘 안되었습니다.

모든 피드백 감사히 잘 받겠습니다.