### PR TITLE
ROFO-149 음식점 수정 리포트 API 수정 대상에 사진 추가

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -90,6 +90,7 @@ enum class ErrorCode(
     NOT_FOOD_SPOTS_HISTORIES_OWNER(HttpStatus.FORBIDDEN, -13003, "해당 음식점 리포트의 소유자가 아닙니다."),
     FOOD_SPOTS_ALREADY_CLOSED(HttpStatus.CONFLICT, -13004, "이미 폐업 처리가 된 음식점입니다."),
     TOO_MANY_REPORT_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, -13005, "일일 리포트 생성 횟수를 초과하였습니다."),
+    UNAUTHORIZED_PHOTO_REMOVE(HttpStatus.FORBIDDEN, -13006, "사진을 삭제할 권한이 없습니다."),
 
     // Review API error 14000대
     FOOD_SPOT_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -14000, "음식점 ID는 양수여야 합니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
@@ -153,6 +153,8 @@ data class FoodSpotsUpdateRequest(
         description = "운영시간 리스트 ex) 변경된, 변경되지 않은 운영시간 모두 입력해주세요. 없을 경우, 생략해주세요",
     )
     val operationHours: List<OperationHoursRequest>?,
+    @Schema(description = "삭제할 이미지 ID 리스트", example = "[1, 2]")
+    val photoIdsToRemove: Set<Long>?,
 ) {
     fun toFoodSpotsHistoryEntity(
         foodSpots: FoodSpots,

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -214,19 +214,20 @@ class FoodSpotsCommandService(
 
         userCommandService.increaseCoin(user.id, foodSpotsHistory.reportType.reportReward.point)
 
-        generatorPhotoNameMap
-            .map {
-                CompletableFuture.supplyAsync({
-                    imageService.upload(it.key, it.value)
-                }, executor)
-            }.forEach { it.join() }
-
-        photosToRemove
-            .map {
-                CompletableFuture.supplyAsync({
-                    imageService.remove(it.fileName)
-                }, executor)
-            }.forEach { it.join() }
+        (
+            generatorPhotoNameMap
+                .map {
+                    CompletableFuture.supplyAsync({
+                        imageService.upload(it.key, it.value)
+                    }, executor)
+                } +
+                photosToRemove
+                    .map {
+                        CompletableFuture.supplyAsync({
+                            imageService.remove(it.fileName)
+                        }, executor)
+                    }
+        ).forEach { it.join() }
     }
 
     private fun isNotPhotosBelongingToFoodSpots(

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -16,6 +16,7 @@ import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.exception.AlreadyClosedFoodSpotsException
 import kr.weit.roadyfoody.foodSpots.exception.NotFoodSpotsHistoriesOwnerException
 import kr.weit.roadyfoody.foodSpots.exception.TooManyReportRequestException
+import kr.weit.roadyfoody.foodSpots.exception.UnauthorizedPhotoRemoveException
 import kr.weit.roadyfoody.foodSpots.repository.FoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSportsOperationHoursRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsFoodCategoryRepository
@@ -198,12 +199,16 @@ class FoodSpotsCommandService(
                 FoodSpotsPhoto.of(foodSpotsHistory, it.key)
             }.also { foodSpotsPhotoRepository.saveAll(it) }
 
-        val photosToRemove =
-            request?.photoIdsToRemove?.let {
-                foodSpotsPhotoRepository.findAllById(request.photoIdsToRemove).also {
-                    foodSpotsPhotoRepository.deleteAll(it)
-                }
-            } ?: emptyList()
+        val requestedPhotoIdsToRemove = request?.photoIdsToRemove ?: emptyList()
+        val photosToRemove = foodSpotsPhotoRepository.findAllById(requestedPhotoIdsToRemove)
+
+        if (requestedPhotoIdsToRemove.size != photosToRemove.size ||
+            isNotPhotosBelongingToFoodSpots(foodSpots.id, photosToRemove)
+        ) {
+            throw UnauthorizedPhotoRemoveException()
+        }
+
+        foodSpotsPhotoRepository.deleteAll(photosToRemove)
 
         entityManager.flush()
 
@@ -223,6 +228,11 @@ class FoodSpotsCommandService(
                 }, executor)
             }.forEach { it.join() }
     }
+
+    private fun isNotPhotosBelongingToFoodSpots(
+        foodSpotsId: Long,
+        photosToRemove: List<FoodSpotsPhoto>,
+    ): Boolean = photosToRemove.any { it.history.foodSpots.id != foodSpotsId }
 
     private fun storeReport(
         foodStoreHistory: FoodSpotsHistory,

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -203,6 +203,7 @@ class FoodSpotsCommandService(
         val photosToRemove = foodSpotsPhotoRepository.findAllById(requestedPhotoIdsToRemove)
 
         if (requestedPhotoIdsToRemove.size != photosToRemove.size ||
+            photosToRemove.any { it.history.user.id != user.id } ||
             isNotPhotosBelongingToFoodSpots(foodSpots.id, photosToRemove)
         ) {
             throw UnauthorizedPhotoRemoveException()

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/domain/FoodSpotsHistory.kt
@@ -70,4 +70,24 @@ class FoodSpotsHistory(
         operationHoursList = emptyList(),
         foodCategoryList = emptyList(),
     )
+
+    companion object {
+        fun from(
+            foodSpots: FoodSpots,
+            user: User,
+            reportType: ReportType = ReportType.STORE_UPDATE,
+        ): FoodSpotsHistory =
+            FoodSpotsHistory(
+                foodSpots = foodSpots,
+                user = user,
+                name = foodSpots.name,
+                foodTruck = foodSpots.foodTruck,
+                open = foodSpots.open,
+                storeClosure = foodSpots.storeClosure,
+                point = foodSpots.point,
+                reportType = reportType,
+                operationHoursList = emptyList(),
+                foodCategoryList = emptyList(),
+            )
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/UnauthorizedPhotoRemoveException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/exception/UnauthorizedPhotoRemoveException.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.foodSpots.exception
+
+import kr.weit.roadyfoody.common.exception.BaseException
+import kr.weit.roadyfoody.common.exception.ErrorCode
+
+class UnauthorizedPhotoRemoveException(
+    message: String = ErrorCode.UNAUTHORIZED_PHOTO_REMOVE.errorMessage,
+) : BaseException(ErrorCode.UNAUTHORIZED_PHOTO_REMOVE, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsController.kt
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
@@ -53,7 +52,7 @@ class FoodSpotsController(
     ) = foodSpotsCommandService.createReport(user, reportRequest, reportPhotos)
 
     @ResponseStatus(CREATED)
-    @PatchMapping("/{foodSpotsId}")
+    @PatchMapping("/{foodSpotsId}", consumes = [MULTIPART_FORM_DATA_VALUE])
     override fun updateFoodSpots(
         @LoginUser
         user: User,
@@ -61,10 +60,14 @@ class FoodSpotsController(
         @PathVariable("foodSpotsId")
         foodSpotsId: Long,
         @Valid
-        @RequestBody
-        request: FoodSpotsUpdateRequest,
+        @RequestPart(required = false)
+        request: FoodSpotsUpdateRequest?,
+        @Size(max = 3, message = "이미지는 최대 3개까지 업로드할 수 있습니다.")
+        @WebPImageList
+        @RequestPart(required = false)
+        reportPhotos: List<MultipartFile>?,
     ) {
-        foodSpotsCommandService.doUpdateReport(user, foodSpotsId, request)
+        foodSpotsCommandService.doUpdateReport(user, foodSpotsId, request, reportPhotos)
     }
 
     @ResponseStatus(NO_CONTENT)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -96,6 +96,7 @@ interface FoodSportsControllerSpec {
             ErrorCode.IMAGES_TOO_MANY,
             ErrorCode.INVALID_IMAGE_TYPE,
             ErrorCode.IMAGES_SIZE_TOO_LARGE,
+            ErrorCode.UNAUTHORIZED_PHOTO_REMOVE,
         ],
     )
     fun updateFoodSpots(

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/presentation/spec/FoodSportsControllerSpec.kt
@@ -93,6 +93,9 @@ interface FoodSportsControllerSpec {
             ErrorCode.NON_POSITIVE_FOOD_SPOT_ID,
             ErrorCode.FOOD_SPOTS_ALREADY_CLOSED,
             ErrorCode.TOO_MANY_REPORT_REQUESTS,
+            ErrorCode.IMAGES_TOO_MANY,
+            ErrorCode.INVALID_IMAGE_TYPE,
+            ErrorCode.IMAGES_SIZE_TOO_LARGE,
         ],
     )
     fun updateFoodSpots(
@@ -101,7 +104,10 @@ interface FoodSportsControllerSpec {
         @Parameter(description = "음식점 ID", required = true, example = "1")
         foodSpotsId: Long,
         @Valid
-        request: FoodSpotsUpdateRequest,
+        request: FoodSpotsUpdateRequest?,
+        @Size(max = 3, message = "이미지는 최대 3개까지 업로드할 수 있습니다.")
+        @WebPImageList
+        reportPhotos: List<MultipartFile>?,
     )
 
     @Operation(

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -133,7 +133,7 @@ class FoodSpotsCommandServiceTest :
                 `when`("정상적인 데이터와 이미지가 들어올 경우") {
                     then("정상적으로 저장되어야 한다.") {
                         foodSpotsCommandService.createReport(
-                            createTestUser(),
+                            user,
                             createTestReportRequest(),
                             createMockPhotoList(ImageFormat.WEBP),
                         )
@@ -143,7 +143,7 @@ class FoodSpotsCommandServiceTest :
                 `when`("정상적인 데이터만 들어올 경우") {
                     then("정상적으로 저장되어야 한다.") {
                         foodSpotsCommandService.createReport(
-                            createTestUser(),
+                            user,
                             createTestReportRequest(),
                             null,
                         )
@@ -156,7 +156,7 @@ class FoodSpotsCommandServiceTest :
                     then("CategoriesNotFoundException 이 발생한다.") {
                         shouldThrow<CategoriesNotFoundException> {
                             foodSpotsCommandService.createReport(
-                                createTestUser(),
+                                user,
                                 createTestReportRequest(),
                                 createMockPhotoList(ImageFormat.WEBP),
                             )
@@ -202,7 +202,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             onlyNameChangeRequest,
                             null,
@@ -228,7 +228,7 @@ class FoodSpotsCommandServiceTest :
                             ),
                         ) { request ->
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 request,
                                 null,
@@ -245,7 +245,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             closeUpdateRequest,
                             null,
@@ -261,7 +261,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             openUpdateRequest,
                             null,
@@ -277,7 +277,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             openUpdateRequest,
                             null,
@@ -305,7 +305,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             onlyCategoryAddRequest,
                             null,
@@ -330,7 +330,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             onlyCategoryDeleteRequest,
                             null,
@@ -359,7 +359,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             categoryAddAndDeleteRequest,
                             null,
@@ -386,7 +386,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             onlyOperationHoursChangeRequest,
                             null,
@@ -423,7 +423,7 @@ class FoodSpotsCommandServiceTest :
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             null,
                             createMockPhotoList(ImageFormat.WEBP),
@@ -440,7 +440,7 @@ class FoodSpotsCommandServiceTest :
                     then("변경된 값이 없으므로 RoadyFoodyBadRequestException 이 발생해야 한다.") {
                         shouldThrow<RoadyFoodyBadRequestException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 noChangeRequest,
                                 null,
@@ -453,7 +453,7 @@ class FoodSpotsCommandServiceTest :
                     then("RoadyFoodyBadRequestException 이 발생해야 한다.") {
                         shouldThrow<RoadyFoodyBadRequestException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 null,
                                 null,
@@ -471,7 +471,7 @@ class FoodSpotsCommandServiceTest :
                     then("AlreadyClosedFoodSpotsException 이 발생해야 한다.") {
                         shouldThrow<AlreadyClosedFoodSpotsException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 closeUpdateRequest,
                                 null,
@@ -547,7 +547,7 @@ class FoodSpotsCommandServiceTest :
                     then("UnauthorizedPhotoRemoveException 이 발생해야 한다.") {
                         shouldThrow<UnauthorizedPhotoRemoveException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 photoRemoveRequest,
                                 null,
@@ -574,7 +574,7 @@ class FoodSpotsCommandServiceTest :
                     then("UnauthorizedPhotoRemoveException 이 발생해야 한다.") {
                         shouldThrow<UnauthorizedPhotoRemoveException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 photoRemoveRequest,
                                 null,
@@ -592,7 +592,7 @@ class FoodSpotsCommandServiceTest :
                     then("UnauthorizedPhotoRemoveException 이 발생해야 한다.") {
                         shouldThrow<UnauthorizedPhotoRemoveException> {
                             foodSpotsCommandService.doUpdateReport(
-                                createTestUser(),
+                                user,
                                 TEST_FOOD_SPOT_ID,
                                 photoRemoveRequest,
                                 null,

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -394,19 +394,21 @@ class FoodSpotsCommandServiceTest :
                     }
                 }
 
-                `when`("기존의 사진을 제거할 경우") {
+                `when`("기존 자신의 사진을 제거할 경우") {
                     val foodSpots = createMockTestFoodSpot()
                     every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
-                    val foodSpotsPhotos = createTestFoodSpotsPhotos(foodSpotsHistory = createMockTestFoodHistory(foodSpots = foodSpots))
-                    every { foodSpotsPhotoRepository.findAllById(any()) } returns foodSpotsPhotos
+                    val foodSpotsHistory = createMockTestFoodHistory(user = user, foodSpots = foodSpots)
+                    val foodSpotsPhotosToRemove = createTestFoodSpotsPhotos(foodSpotsHistory = foodSpotsHistory)
+                    every { foodSpotsPhotoRepository.findAllById(any()) } returns foodSpotsPhotosToRemove
                     every { foodSpotsPhotoRepository.deleteAll(any()) } just runs
                     every { imageService.remove(any()) } just runs
 
-                    val photoRemoveRequest = createTestFoodSpotsUpdateRequest(photoIdsToRemove = foodSpotsPhotos.map { it.id }.toSet())
+                    val photoRemoveRequest =
+                        createTestFoodSpotsUpdateRequest(photoIdsToRemove = foodSpotsPhotosToRemove.map { it.id }.toSet())
 
                     then("정상적으로 업데이트 되어야 한다.") {
                         foodSpotsCommandService.doUpdateReport(
-                            createTestUser(),
+                            user,
                             TEST_FOOD_SPOT_ID,
                             photoRemoveRequest,
                             null,
@@ -472,6 +474,59 @@ class FoodSpotsCommandServiceTest :
                                 createTestUser(),
                                 TEST_FOOD_SPOT_ID,
                                 closeUpdateRequest,
+                                null,
+                            )
+                        }
+                    }
+                }
+
+                `when`("삭제하려는 사진이 전부 다른 회원의 것일 경우") {
+                    val foodSpots = createMockTestFoodSpot(id = TEST_FOOD_SPOT_ID)
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+
+                    val otherUser = createTestUser(TEST_OTHER_USER_ID)
+                    val otherUserFoodSpotsHistory = createMockTestFoodHistory(user = otherUser, foodSpots = foodSpots)
+                    val otherUserFoodSpotsPhotosToRemove = createTestFoodSpotsPhotos(foodSpotsHistory = otherUserFoodSpotsHistory)
+                    every { foodSpotsPhotoRepository.findAllById(any()) } returns otherUserFoodSpotsPhotosToRemove
+
+                    val photoRemoveRequest =
+                        createTestFoodSpotsUpdateRequest(photoIdsToRemove = otherUserFoodSpotsPhotosToRemove.map { it.id }.toSet())
+
+                    then("UnauthorizedPhotoRemoveException 이 발생해야 한다.") {
+                        shouldThrow<UnauthorizedPhotoRemoveException> {
+                            foodSpotsCommandService.doUpdateReport(
+                                user,
+                                TEST_FOOD_SPOT_ID,
+                                photoRemoveRequest,
+                                null,
+                            )
+                        }
+                    }
+                }
+
+                `when`("삭제하려는 사진 중 다른 회원의 것도 섞여 있을 경우") {
+                    val foodSpots = createMockTestFoodSpot(id = TEST_FOOD_SPOT_ID)
+                    every { foodSpotsRepository.findById(any()) } returns Optional.of(foodSpots)
+                    val foodSpotsHistory = createMockTestFoodHistory(user = user, foodSpots = foodSpots)
+                    val foodSpotsPhotos =
+                        createTestFoodSpotsPhoto(foodSpotsHistory = foodSpotsHistory)
+
+                    val otherUser = createTestUser(TEST_OTHER_USER_ID)
+                    val otherUserFoodSpotsHistory = createMockTestFoodHistory(user = otherUser, foodSpots = foodSpots)
+                    val otherUserFoodSpotsPhoto = createTestFoodSpotsPhoto(foodSpotsHistory = otherUserFoodSpotsHistory)
+
+                    val photosToRemove = listOf(foodSpotsPhotos, otherUserFoodSpotsPhoto)
+                    every { foodSpotsPhotoRepository.findAllById(any()) } returns photosToRemove
+
+                    val photoRemoveRequest =
+                        createTestFoodSpotsUpdateRequest(photoIdsToRemove = photosToRemove.map { it.id }.toSet())
+
+                    then("UnauthorizedPhotoRemoveException 이 발생해야 한다.") {
+                        shouldThrow<UnauthorizedPhotoRemoveException> {
+                            foodSpotsCommandService.doUpdateReport(
+                                user,
+                                TEST_FOOD_SPOT_ID,
+                                photoRemoveRequest,
                                 null,
                             )
                         }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -76,6 +76,8 @@ const val TEST_UPDATE_OPERATION_HOURS_OPEN = "10:00"
 const val TEST_UPDATE_OPERATION_HOURS_CLOSE = "13:59"
 const val TEST_FOOD_SPOTS_HISTORY_ID = 1L
 const val TEST_INVALID_FOOD_SPOTS_HISTORY_ID = -1L
+const val TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME = "request"
+const val TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO = "reportPhotos"
 
 fun createMockTestFoodSpot(
     id: Long = 0L,
@@ -132,6 +134,13 @@ fun createTestFoodHistory(
 
 fun createTestFoodSpotsPhoto(foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory()) =
     FoodSpotsPhoto(0L, foodSpotsHistory, TEST_PHOTO_NAME)
+
+fun createTestFoodSpotsPhotos(
+    size: Int = 2,
+    foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory(),
+) = List(size) {
+    createTestFoodSpotsPhoto(foodSpotsHistory)
+}
 
 fun createTestReportRequest(
     name: String = TEST_FOOD_SPOT_NAME,
@@ -358,6 +367,7 @@ fun createTestFoodSpotsUpdateRequest(
     closed: Boolean = TEST_FOOD_SPOT_STORE_CLOSURE,
     categories: Set<Long> = createTestFoodCategories().map { it.id }.toSet(),
     operationHours: List<OperationHoursRequest> = listOf(createOperationHoursRequest()),
+    photoIdsToRemove: Set<Long>? = null,
 ): FoodSpotsUpdateRequest =
     FoodSpotsUpdateRequest(
         name,
@@ -367,6 +377,7 @@ fun createTestFoodSpotsUpdateRequest(
         closed,
         categories,
         operationHours,
+        photoIdsToRemove,
     )
 
 // Entity 로부터 역으로 Request 를 만들어냅니다.
@@ -380,6 +391,7 @@ fun createTestFoodSpotsUpdateRequestFromEntity(foodSpots: FoodSpots = createTest
         foodSpots.storeClosure,
         foodSpots.foodCategoryList.map { it.foodCategory.id }.toSet(),
         createTestFoodSpotsOperationHoursRequestsFromEntities(foodSpots.operationHoursList),
+        null,
     )
 
 fun createTestFoodSpotsOperationHoursRequestsFromEntities(operationHours: List<FoodSpotsOperationHours>): List<OperationHoursRequest> =

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -132,14 +132,16 @@ fun createTestFoodHistory(
     foodCategories: List<ReportFoodCategory> = listOf(),
 ) = FoodSpotsHistory(id, foodSpots, user, name, foodTruck, open, storeClosure, point, reportType, operationHours, foodCategories)
 
-fun createTestFoodSpotsPhoto(foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory()) =
-    FoodSpotsPhoto(0L, foodSpotsHistory, TEST_PHOTO_NAME)
+fun createTestFoodSpotsPhoto(
+    foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory(),
+    id: Long = 0L,
+) = FoodSpotsPhoto(id, foodSpotsHistory, TEST_PHOTO_NAME)
 
 fun createTestFoodSpotsPhotos(
     size: Int = 2,
     foodSpotsHistory: FoodSpotsHistory = createTestFoodHistory(),
-) = List(size) {
-    createTestFoodSpotsPhoto(foodSpotsHistory)
+) = List(size) { id ->
+    createTestFoodSpotsPhoto(foodSpotsHistory, id + 1L)
 }
 
 fun createTestReportRequest(

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -15,6 +15,8 @@ import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsQueryService
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_HISTORY_ID
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_REQUEST_NAME
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_REQUEST_PHOTO
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME
+import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_NAME_EMPTY
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_NAME_INVALID_STR
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOT_NAME_TOO_LONG
@@ -40,7 +42,7 @@ import kr.weit.roadyfoody.support.utils.createTestImageFile
 import kr.weit.roadyfoody.support.utils.deleteWithAuth
 import kr.weit.roadyfoody.support.utils.getWithAuth
 import kr.weit.roadyfoody.support.utils.multipartWithAuth
-import kr.weit.roadyfoody.support.utils.patchWithAuth
+import kr.weit.roadyfoody.support.utils.toPatch
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.MockMvc
@@ -293,26 +295,75 @@ class FoodSpotsControllerTest(
             }
 
             given("PATCH $requestPath/{foodSpotsId} Test") {
-                every { foodSpotsCommandService.doUpdateReport(any(), any(), any()) } just runs
+                beforeEach {
+                    every { foodSpotsCommandService.doUpdateReport(any(), any(), any(), any()) } just runs
+                }
+                val reportPhotos = createMockPhotoList(WEBP)
                 `when`("정상적인 요청이 들어올 경우") {
                     val request = createTestFoodSpotsUpdateRequest()
                     then("해당 가게 정보를 수정한다.") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(objectMapper.writeValueAsString(request))
-                                    .contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        reportPhotos[0].bytes,
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        reportPhotos[1].bytes,
+                                    ).with(toPatch()),
+                            ).andExpect(status().isCreated)
+                    }
+                }
+
+                `when`("이미지 파일을 제외한 수정 요청이 들어올 경우") {
+                    then("해당 가게 정보를 수정하며 201 을 반환한다.") {
+                        mockMvc
+                            .perform(
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(createTestFoodSpotsUpdateRequest()).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
+                            ).andExpect(status().isCreated)
+                    }
+                }
+
+                `when`("이미지 파일만 들어올 경우") {
+                    then("해당 가게 정보를 수정하며 201 을 반환한다.") {
+                        mockMvc
+                            .perform(
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        reportPhotos[0].bytes,
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        reportPhotos[1].bytes,
+                                    ).with(toPatch()),
                             ).andExpect(status().isCreated)
                     }
                 }
 
                 `when`("음식점 ID가 양수가 아닌 경우") {
+                    val request = createTestFoodSpotsUpdateRequest()
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_INVALID_FOOD_SPOT_ID")
-                                    .content(objectMapper.writeValueAsString(createTestFoodSpotsUpdateRequest()))
-                                    .contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_INVALID_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -322,10 +373,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -335,10 +389,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -348,10 +405,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -361,10 +421,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -374,10 +437,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -393,10 +459,84 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                patchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
-                                    .content(
-                                        objectMapper.writeValueAsString(request),
-                                    ).contentType("application/json"),
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).with(toPatch()),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("이미지가 3개 초과인 경우") {
+                    val request = createTestReportRequest()
+                    val tooLargeReportPhotos = createMockPhotoList(WEBP, size = 4)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        tooLargeReportPhotos[0].bytes,
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        tooLargeReportPhotos[1].bytes,
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        tooLargeReportPhotos[2].bytes,
+                                    ).file(
+                                        TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
+                                        tooLargeReportPhotos[3].bytes,
+                                    ).with(toPatch()),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("이미지 형식이 webp가 아닌 경우") {
+                    val request = createTestReportRequest()
+                    val reportPhotosJpeg = createMockPhotoList(ImageFormat.JPEG)
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                multipartWithAuth(requestPath)
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_REQUEST_NAME,
+                                            objectMapper
+                                                .writeValueAsBytes(request)
+                                                .inputStream(),
+                                        ),
+                                    ).file(TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME, reportPhotosJpeg[0].bytes)
+                                    .file(TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME, reportPhotosJpeg[1].bytes)
+                                    .with(toPatch()),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+
+                `when`("파일의 크기가 1MB를 초과하면") {
+                    val request = createTestReportRequest()
+                    val mockFile: MockMultipartFile = mockk<MockMultipartFile>()
+                    every { mockFile.size } returns 1024 * 1024 + 1
+                    every { mockFile.name } returns TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO
+                    every { mockFile.inputStream } returns createTestImageFile(WEBP).inputStream
+                    then("400을 반환") {
+                        mockMvc
+                            .perform(
+                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                    .file(
+                                        createMultipartFile(
+                                            TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
+                                            objectMapper.writeValueAsString(request).byteInputStream(),
+                                        ),
+                                    ).file(mockFile)
+                                    .with(toPatch()),
                             ).andExpect(status().isBadRequest)
                     }
                 }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/presentation/api/FoodSpotsControllerTest.kt
@@ -41,8 +41,8 @@ import kr.weit.roadyfoody.support.utils.createMultipartFile
 import kr.weit.roadyfoody.support.utils.createTestImageFile
 import kr.weit.roadyfoody.support.utils.deleteWithAuth
 import kr.weit.roadyfoody.support.utils.getWithAuth
+import kr.weit.roadyfoody.support.utils.multipartPatchWithAuth
 import kr.weit.roadyfoody.support.utils.multipartWithAuth
-import kr.weit.roadyfoody.support.utils.toPatch
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.MockMvc
@@ -304,7 +304,7 @@ class FoodSpotsControllerTest(
                     then("해당 가게 정보를 수정한다.") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
@@ -316,7 +316,7 @@ class FoodSpotsControllerTest(
                                     ).file(
                                         TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
                                         reportPhotos[1].bytes,
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isCreated)
                     }
                 }
@@ -325,13 +325,13 @@ class FoodSpotsControllerTest(
                     then("해당 가게 정보를 수정하며 201 을 반환한다.") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(createTestFoodSpotsUpdateRequest()).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isCreated)
                     }
                 }
@@ -340,14 +340,14 @@ class FoodSpotsControllerTest(
                     then("해당 가게 정보를 수정하며 201 을 반환한다.") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
                                         reportPhotos[0].bytes,
                                     ).file(
                                         TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
                                         reportPhotos[1].bytes,
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isCreated)
                     }
                 }
@@ -357,13 +357,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_INVALID_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_INVALID_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -373,13 +373,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -389,13 +389,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -405,13 +405,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -421,13 +421,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -437,13 +437,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -459,13 +459,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -476,7 +476,7 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
@@ -494,7 +494,7 @@ class FoodSpotsControllerTest(
                                     ).file(
                                         TEST_FOOD_SPOTS_UPDATE_REQUEST_PHOTO,
                                         tooLargeReportPhotos[3].bytes,
-                                    ).with(toPatch()),
+                                    ),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -505,7 +505,7 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth(requestPath)
+                                multipartPatchWithAuth(requestPath)
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_REQUEST_NAME,
@@ -514,8 +514,7 @@ class FoodSpotsControllerTest(
                                                 .inputStream(),
                                         ),
                                     ).file(TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME, reportPhotosJpeg[0].bytes)
-                                    .file(TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME, reportPhotosJpeg[1].bytes)
-                                    .with(toPatch()),
+                                    .file(TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME, reportPhotosJpeg[1].bytes),
                             ).andExpect(status().isBadRequest)
                     }
                 }
@@ -529,14 +528,13 @@ class FoodSpotsControllerTest(
                     then("400을 반환") {
                         mockMvc
                             .perform(
-                                multipartWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
+                                multipartPatchWithAuth("$requestPath/$TEST_FOOD_SPOT_ID")
                                     .file(
                                         createMultipartFile(
                                             TEST_FOOD_SPOTS_UPDATE_REQUEST_NAME,
                                             objectMapper.writeValueAsString(request).byteInputStream(),
                                         ),
-                                    ).file(mockFile)
-                                    .with(toPatch()),
+                                    ).file(mockFile),
                             ).andExpect(status().isBadRequest)
                     }
                 }

--- a/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.support.utils
 
+import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -8,7 +9,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multi
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
-import org.springframework.test.web.servlet.request.RequestPostProcessor
 
 fun MockHttpServletRequestBuilder.withAuth(): MockHttpServletRequestBuilder = this.header("userid", 1)
 
@@ -22,12 +22,8 @@ fun multipartWithAuth(url: String) = multipart(url).apply { header("userid", 1) 
 
 fun patchWithAuth(url: String) = patch(url).withAuth()
 
+fun multipartPatchWithAuth(url: String) = multipart(HttpMethod.PATCH, url).apply { header("userid", 1) }
+
 fun putWithAuth(url: String) = put(url).withAuth()
 
 fun deleteWithAuth(url: String) = delete(url).withAuth()
-
-fun toPatch(): RequestPostProcessor =
-    RequestPostProcessor { request ->
-        request.method = "PATCH"
-        request
-    }

--- a/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multi
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.request.RequestPostProcessor
 
 fun MockHttpServletRequestBuilder.withAuth(): MockHttpServletRequestBuilder = this.header("userid", 1)
 
@@ -24,3 +25,9 @@ fun patchWithAuth(url: String) = patch(url).withAuth()
 fun putWithAuth(url: String) = put(url).withAuth()
 
 fun deleteWithAuth(url: String) = delete(url).withAuth()
+
+fun toPatch(): RequestPostProcessor =
+    RequestPostProcessor { request ->
+        request.method = "PATCH"
+        request
+    }


### PR DESCRIPTION
### 개요
리포트 작성 시 음식점 사진 중 잘못된 잘못된 것이 있을 수 있어 수정 대상에 사진을 추가해야합니다.

### 변경사항
- MockMvc 테스트 중 multipart 요청을 patch 요청으로 바꾸는 정적함수 생성
- FoodSpotsHistories 생성 함수 생성 (FoodSpots, User 를 패러미터로 입력)
- 음식점 수정 리포트 API 의 수정 대상에 사진 추가
- 음식점 수정 리포트 API 기존 request 를 nullable 하게 변경 및 관련 로직 수정


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-149) 


### 리뷰어에게 하고 싶은 말
사진 제거 시 그 사진이 해당 FoodSpots 에 속한 사진인지 검증하지 않았습니다. 
(클라이언트쪽에서 해당 FoodSpots 에 속한 사진만 나타낼테니 다른 음식점 사진을 삭제한다같은 문제가 발생할 확률이 적다 생각했습니다.) 
같은 이유로 삭제요청한 사진 id 가 실제 존재하는 id 인지에 대한 부분도 검증하지 않았습니다. 
in 절로 조회하며 존재하지 않는 사진은 제거될 일도 없어 시스템에 문제를 주지 않을 것이라 생각했습니다.


이번에 `doUpdateFoodSpots` 에 nullable 한 인자가 두 개 생기면서 두 nullable 한 경우를
한 흐름에 다 집어넣으려 하니 생각보다 코드가 복잡해진 것 같습니다. 개선할 방법이 있다면 꼭 알려주시면 감사하겠습니다.

모든 피드백 감사히 받겠습니다.