### PR TITLE
ROFO-139 유저 정보 변경 API

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/auth/application/service/AuthCommandService.kt
@@ -50,7 +50,7 @@ class AuthCommandService(
 
         if (profileImage != null) {
             val imageName = imageService.generateImageName(profileImage)
-            user.profile.changeProfileImageName(imageName)
+            user.changeProfileImageName(imageName)
             imageService.upload(imageName, profileImage)
         }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -104,4 +104,6 @@ enum class ErrorCode(
 
     // User API error 15000대
     USER_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -15000, "유저 ID는 양수여야 합니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, -15001, "이미 사용중인 닉네임입니다."),
+    PROFILE_IMAGE_NOT_EXISTS(HttpStatus.NOT_FOUND, -15002, "프로필 이미지가 존재하지 않습니다."),
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
@@ -1,0 +1,12 @@
+package kr.weit.roadyfoody.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Pattern
+import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX_DESC
+import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX_STR
+
+data class UserNicknameRequest(
+    @Schema(description = "닉네임. $NICKNAME_REGEX_DESC", example = "테스트닉네임123")
+    @field:Pattern(regexp = NICKNAME_REGEX_STR, message = NICKNAME_REGEX_DESC)
+    val nickname: String,
+)

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
@@ -56,16 +56,20 @@ class UserCommandService(
     ) {
         val beforeProfile = user.profile.profileImageName
         val imageName = imageService.generateImageName(profileImage)
-        user.profile.changeProfileImageName(imageName)
+        user.changeProfileImageName(imageName)
         userRepository.save(user)
         imageService.upload(imageName, profileImage)
-        beforeProfile?.let { imageService.remove(it) }
+        beforeProfile?.let {
+            if (it != imageName) {
+                imageService.remove(it)
+            }
+        }
     }
 
     @Transactional
     fun deleteProfileImage(user: User) {
         user.profile.profileImageName?.let { imageName ->
-            user.profile.changeProfileImageName()
+            user.changeProfileImageName()
             userRepository.save(user)
             imageService.remove(imageName)
         } ?: throw RoadyFoodyBadRequestException(ErrorCode.PROFILE_IMAGE_NOT_EXISTS)

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandService.kt
@@ -3,13 +3,18 @@ package kr.weit.roadyfoody.user.application.service
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.global.annotation.DistributedLock
+import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.user.domain.User
 import kr.weit.roadyfoody.user.repository.UserRepository
 import kr.weit.roadyfoody.user.repository.getByUserId
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 class UserCommandService(
     private val userRepository: UserRepository,
+    private val imageService: ImageService,
 ) {
     @DistributedLock(lockName = "COIN-LOCK", identifier = "userId")
     fun decreaseCoin(
@@ -30,5 +35,39 @@ class UserCommandService(
     ) {
         val user = userRepository.getByUserId(userId)
         user.increaseCoin(coin)
+    }
+
+    @Transactional
+    fun updateNickname(
+        user: User,
+        nickname: String,
+    ) {
+        if (userRepository.existsByProfileNickname(nickname)) {
+            throw RoadyFoodyBadRequestException(ErrorCode.NICKNAME_ALREADY_EXISTS)
+        }
+        user.changeNickname(nickname)
+        userRepository.save(user)
+    }
+
+    @Transactional
+    fun updateProfileImage(
+        user: User,
+        profileImage: MultipartFile,
+    ) {
+        val beforeProfile = user.profile.profileImageName
+        val imageName = imageService.generateImageName(profileImage)
+        user.profile.changeProfileImageName(imageName)
+        userRepository.save(user)
+        imageService.upload(imageName, profileImage)
+        beforeProfile?.let { imageService.remove(it) }
+    }
+
+    @Transactional
+    fun deleteProfileImage(user: User) {
+        user.profile.profileImageName?.let { imageName ->
+            user.profile.changeProfileImageName()
+            userRepository.save(user)
+            imageService.remove(imageName)
+        } ?: throw RoadyFoodyBadRequestException(ErrorCode.PROFILE_IMAGE_NOT_EXISTS)
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
@@ -57,7 +57,11 @@ class User(
     }
 
     fun changeNickname(nickname: String) {
-        profile = profile.copy(nickname = nickname)
+        profile = profile.changeNickname(nickname)
+    }
+
+    fun changeProfileImageName(profileImageName: String? = null) {
+        profile = profile.changeProfileImageName(profileImageName)
     }
 }
 
@@ -66,11 +70,9 @@ class Profile(
     @Column(length = 48, nullable = false, unique = true)
     val nickname: String,
     @Column(length = 50)
-    var profileImageName: String? = null,
+    val profileImageName: String? = null,
 ) {
-    fun changeProfileImageName(profileImageName: String? = null) {
-        this.profileImageName = profileImageName
-    }
+    fun changeProfileImageName(profileImageName: String? = null) = Profile(this.nickname, profileImageName)
 
-    fun copy(nickname: String): Profile = Profile(nickname, this.profileImageName)
+    fun changeNickname(nickname: String) = Profile(nickname, this.profileImageName)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
@@ -55,16 +55,22 @@ class User(
         this.coin += plusCoin
         return this.coin
     }
+
+    fun changeNickname(nickname: String) {
+        profile = profile.copy(nickname = nickname)
+    }
 }
 
 @Embeddable
 class Profile(
-    @Column(length = 48, updatable = false, nullable = false, unique = true)
+    @Column(length = 48, nullable = false, unique = true)
     val nickname: String,
     @Column(length = 50)
     var profileImageName: String? = null,
 ) {
-    fun changeProfileImageName(profileImageName: String) {
+    fun changeProfileImageName(profileImageName: String? = null) {
         this.profileImageName = profileImageName
     }
+
+    fun copy(nickname: String): Profile = Profile(nickname, this.profileImageName)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
@@ -1,24 +1,38 @@
 package kr.weit.roadyfoody.user.presentation.api
 
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
 import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.dto.SliceResponse
+import kr.weit.roadyfoody.global.validator.MaxFileSize
+import kr.weit.roadyfoody.global.validator.WebPImage
 import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+import kr.weit.roadyfoody.user.application.dto.UserNicknameRequest
 import kr.weit.roadyfoody.user.application.dto.UserReportHistoriesResponse
 import kr.weit.roadyfoody.user.application.dto.UserReviewResponse
+import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.application.service.UserQueryService
 import kr.weit.roadyfoody.user.domain.User
 import kr.weit.roadyfoody.user.presentation.spec.UserControllerSpec
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/users")
 class UserController(
     private val userQueryService: UserQueryService,
+    private val userCommandService: UserCommandService,
 ) : UserControllerSpec {
     @GetMapping("/me")
     override fun getLoginUserInfo(
@@ -49,4 +63,38 @@ class UserController(
         @RequestParam(required = false)
         lastId: Long?,
     ): SliceResponse<UserReviewResponse> = userQueryService.getUserReviews(userId, size, lastId)
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/nickname")
+    override fun updateNickname(
+        @LoginUser
+        user: User,
+        @RequestBody
+        @Valid
+        userNicknameRequest: UserNicknameRequest,
+    ) {
+        userCommandService.updateNickname(user, userNicknameRequest.nickname)
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/profile", consumes = [MULTIPART_FORM_DATA_VALUE])
+    override fun updateProfile(
+        @LoginUser
+        user: User,
+        @RequestPart
+        @MaxFileSize
+        @WebPImage
+        profileImage: MultipartFile,
+    ) {
+        userCommandService.updateProfileImage(user, profileImage)
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/profile")
+    override fun deleteProfile(
+        @LoginUser
+        user: User,
+    ) {
+        userCommandService.deleteProfileImage(user)
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/api/UserController.kt
@@ -78,7 +78,7 @@ class UserController(
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/profile", consumes = [MULTIPART_FORM_DATA_VALUE])
-    override fun updateProfile(
+    override fun updateProfileImage(
         @LoginUser
         user: User,
         @RequestPart

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
@@ -7,13 +7,18 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive
+import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.dto.SliceResponse
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.ErrorResponse
 import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
+import kr.weit.roadyfoody.global.validator.MaxFileSize
+import kr.weit.roadyfoody.global.validator.WebPImage
 import kr.weit.roadyfoody.user.application.dto.UserInfoResponse
+import kr.weit.roadyfoody.user.application.dto.UserNicknameRequest
 import kr.weit.roadyfoody.user.application.dto.UserReportHistoriesResponse
 import kr.weit.roadyfoody.user.application.dto.UserReviewResponse
 import kr.weit.roadyfoody.user.domain.User
@@ -21,7 +26,10 @@ import kr.weit.roadyfoody.user.utils.SliceReportHistories
 import kr.weit.roadyfoody.user.utils.SliceUserReview
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = SwaggerTag.USER)
 interface UserControllerSpec {
@@ -142,4 +150,69 @@ interface UserControllerSpec {
         @RequestParam(required = false)
         lastId: Long?,
     ): SliceResponse<UserReviewResponse>
+
+    @Operation(
+        description = "유저의 닉네임 변경 API",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "닉네임 변경 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.NICKNAME_ALREADY_EXISTS,
+            ErrorCode.INVALID_NICKNAME,
+        ],
+    )
+    fun updateNickname(
+        @LoginUser
+        user: User,
+        @RequestBody
+        @Valid
+        userNicknameRequest: UserNicknameRequest,
+    )
+
+    @Operation(
+        description = "유저의 프로필 이미지 변경 API",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "프로필 이미지 변경 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.INVALID_WEBP_IMAGE,
+            ErrorCode.MAX_FILE_SIZE_EXCEEDED,
+        ],
+    )
+    fun updateProfile(
+        @LoginUser
+        user: User,
+        @RequestPart
+        @MaxFileSize
+        @WebPImage
+        profileImage: MultipartFile,
+    )
+
+    @Operation(
+        description = "유저의 프로필 이미지 삭제 API",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "프로필 이미지 삭제 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.PROFILE_IMAGE_NOT_EXISTS,
+        ],
+    )
+    fun deleteProfile(
+        @LoginUser user: User,
+    )
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/presentation/spec/UserControllerSpec.kt
@@ -189,7 +189,7 @@ interface UserControllerSpec {
             ErrorCode.MAX_FILE_SIZE_EXCEEDED,
         ],
     )
-    fun updateProfile(
+    fun updateProfileImage(
         @LoginUser
         user: User,
         @RequestPart

--- a/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/support/utils/MockMvcHelper.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.support.utils
 
+import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -20,6 +21,8 @@ fun postWithAuth(url: String) = post(url).withAuth()
 fun multipartWithAuth(url: String) = multipart(url).apply { header("userid", 1) }
 
 fun patchWithAuth(url: String) = patch(url).withAuth()
+
+fun multipartPatchWithAuth(url: String) = multipart(HttpMethod.PATCH, url).apply { header("userid", 1) }
 
 fun putWithAuth(url: String) = put(url).withAuth()
 

--- a/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/application/service/UserCommandServiceTest.kt
@@ -3,6 +3,7 @@ package kr.weit.roadyfoody.user.application.service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import kr.weit.roadyfoody.auth.fixture.PROFILE_IMAGE_FILE_NAME
@@ -63,9 +64,9 @@ class UserCommandServiceTest :
         given("updateNickname 테스트") {
             val nickname = TEST_MAX_LENGTH_NICKNAME
             `when`("닉네임을 변경하면") {
-                user.changeNickname(nickname)
                 every { userRepository.save(user) } returns user
                 every { userRepository.existsByProfileNickname(nickname) } returns false
+                user.profile.nickname shouldNotBe nickname
                 userCommandService.updateNickname(user, nickname)
                 then("닉네임이 변경된다.") {
                     user.profile.nickname shouldBe nickname
@@ -88,7 +89,7 @@ class UserCommandServiceTest :
             val profileImage = mockk<MultipartFile>()
             var imageName = TEST_USER_PROFILE_IMAGE_NAME
             `when`("기본 프로필에서 프로필을 변경하면") {
-                user.profile.changeProfileImageName()
+                user.changeProfileImageName()
                 every { imageService.generateImageName(profileImage) } returns imageName
                 every { userRepository.save(user) } returns user
                 every { imageService.upload(imageName, profileImage) } returns Unit
@@ -127,8 +128,9 @@ class UserCommandServiceTest :
             }
 
             `when`("프로필 이미지가 존재하지 않으면") {
-                user.profile.profileImageName = null
+                user.changeProfileImageName()
                 then("PROFILE_IMAGE_NOT_EXISTS 에러가 발생한다.") {
+                    user.profile.profileImageName shouldBe null
                     val ex =
                         shouldThrow<RoadyFoodyBadRequestException> {
                             userCommandService.deleteProfileImage(user)

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.user.fixture
 
+import kr.weit.roadyfoody.user.application.dto.UserNicknameRequest
 import kr.weit.roadyfoody.user.domain.Profile
 import kr.weit.roadyfoody.user.domain.SocialLoginType
 import kr.weit.roadyfoody.user.domain.User
@@ -36,6 +37,8 @@ fun createTestUser(
 )
 
 fun createTestUsers(size: Int = 5) = List(size) { createTestUser(it.toLong() + 1) }
+
+fun createTestUserNicknameRequest(nickname: String = TEST_USER_NICKNAME) = UserNicknameRequest(nickname)
 
 // fail case
 const val TEST_NONEXISTENT_ID = 0L


### PR DESCRIPTION
### 개요
- 유저가 스스로의 닉네임과 프로필을 변경할수 있어야한다.

### 변경사항
- 닉네임/프로필 사진 변경 API
- 프로필 사진 삭제(기본 프로필로 하고자 할 때)
- nickname updatable = true 변경
- changeProfileImageName 함수 기본값 null로 변경

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-139) 

### 리뷰어에게 하고 싶은 말
😀