### PR TITLE
ROFO-157 유저 일일 리포트 생성 횟수 변경 API 작성

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
@@ -2,14 +2,19 @@ package kr.weit.roadyfoody.admin.application.service
 
 import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
 import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
+import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService.Companion.getFoodSpotsReportCountKey
 import kr.weit.roadyfoody.user.repository.UserRepository
 import kr.weit.roadyfoody.user.repository.getByUserId
+import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 
+@Profile("!stable")
 @Service
 class AdminCommandService(
     private val userRepository: UserRepository,
     private val jwtUtil: JwtUtil,
+    private val redisTemplate: RedisTemplate<String, String>,
 ) {
     companion object {
         private const val USER_ACCESS_TOKEN_EXPIRE_TIME = 1_000_000_000L
@@ -19,5 +24,12 @@ class AdminCommandService(
         val user = userRepository.getByUserId(userId)
         val accessToken = jwtUtil.generateAccessToken(user.id, USER_ACCESS_TOKEN_EXPIRE_TIME)
         return UserAccessTokenResponse(accessToken)
+    }
+
+    fun updateUserDailyReportCount(
+        userId: Long,
+        dailyReportCount: Int,
+    ) {
+        redisTemplate.opsForValue().set(getFoodSpotsReportCountKey(userId), dailyReportCount.toString())
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandService.kt
@@ -3,6 +3,7 @@ package kr.weit.roadyfoody.admin.application.service
 import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
 import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService.Companion.getFoodSpotsReportCountKey
+import kr.weit.roadyfoody.user.exception.UserNotFoundException
 import kr.weit.roadyfoody.user.repository.UserRepository
 import kr.weit.roadyfoody.user.repository.getByUserId
 import org.springframework.context.annotation.Profile
@@ -30,6 +31,9 @@ class AdminCommandService(
         userId: Long,
         dailyReportCount: Int,
     ) {
+        if (userRepository.existsById(userId).not()) {
+            throw UserNotFoundException("$userId ID 의 사용자는 존재하지 않습니다.")
+        }
         redisTemplate.opsForValue().set(getFoodSpotsReportCountKey(userId), dailyReportCount.toString())
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/application/service/AdminQueryService.kt
@@ -3,9 +3,11 @@ package kr.weit.roadyfoody.admin.application.service
 import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponse
 import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
 import kr.weit.roadyfoody.user.repository.UserRepository
+import org.springframework.context.annotation.Profile
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
+@Profile("!stable")
 @Service
 class AdminQueryService(
     private val userRepository: UserRepository,

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminController.kt
@@ -1,5 +1,7 @@
 package kr.weit.roadyfoody.admin.presentation.api
 
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
 import kr.weit.roadyfoody.admin.application.service.AdminCommandService
 import kr.weit.roadyfoody.admin.application.service.AdminQueryService
 import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
@@ -8,9 +10,13 @@ import kr.weit.roadyfoody.admin.presentation.spec.AdminControllerSpec
 import org.springframework.context.annotation.Profile
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @Profile("!stable")
@@ -27,6 +33,20 @@ class AdminController(
 
     @GetMapping("/users/{userId}/token")
     override fun getUserAccessToken(
+        @Positive
         @PathVariable userId: Long,
     ): UserAccessTokenResponse = adminCommandService.getUserAccessToken(userId)
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PutMapping("/users/{userId}/daily-report-count")
+    override fun updateUserDailyReportCount(
+        @PathVariable
+        @Positive
+        userId: Long,
+        @RequestParam
+        @PositiveOrZero
+        dailyReportCount: Int,
+    ) {
+        adminCommandService.updateUserDailyReportCount(userId, dailyReportCount)
+    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/spec/AdminControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/admin/presentation/spec/AdminControllerSpec.kt
@@ -8,9 +8,13 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
 import kr.weit.roadyfoody.admin.dto.SimpleUserInfoResponses
 import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
+import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.ErrorResponse
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 import org.springframework.data.domain.Pageable
 import org.springframework.http.MediaType
@@ -88,8 +92,61 @@ interface AdminControllerSpec {
             ),
         ],
     )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.USER_ID_NON_POSITIVE,
+        ],
+    )
     fun getUserAccessToken(
         @Parameter(description = "유저 아이디", required = true, example = "1")
+        @Positive
         userId: Long,
     ): UserAccessTokenResponse
+
+    @Operation(
+        summary = "유저 일일 리포트 생성 횟수 변경",
+        description = "유저 일일 리포트 생성 횟수를 변경합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "204",
+                description = "생성 횟수 변경 성공",
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "생성 횟수 변경 실패",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Not found user",
+                                summary = "NOT_FOUND_USER",
+                                value = """
+                                {
+                                    "code": -10009,
+                                    "errorMessage": "10 ID 의 사용자는 존재하지 않습니다."
+                                }
+                            """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.USER_ID_NON_POSITIVE,
+            ErrorCode.DAILY_REPORT_COUNT_NEGATIVE,
+        ],
+    )
+    fun updateUserDailyReportCount(
+        @Parameter(description = "유저 아이디", required = true, example = "1")
+        @Positive
+        userId: Long,
+        @Parameter(description = "변경할 일일 리포트 생성 횟수", required = true, example = "0")
+        @PositiveOrZero
+        dailyReportCount: Int,
+    )
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -107,4 +107,7 @@ enum class ErrorCode(
     USER_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -15000, "유저 ID는 양수여야 합니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, -15001, "이미 사용중인 닉네임입니다."),
     PROFILE_IMAGE_NOT_EXISTS(HttpStatus.NOT_FOUND, -15002, "프로필 이미지가 존재하지 않습니다."),
+
+    // Admin API error 16000대
+    DAILY_REPORT_COUNT_NEGATIVE(HttpStatus.BAD_REQUEST, -16000, "일일 리포트 생성 횟수는 양수 또는 0이여야 합니다."),
 }

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceIntegrationTest.kt
@@ -1,24 +1,27 @@
 package kr.weit.roadyfoody.admin.application.service
 
+import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService.Companion.getFoodSpotsReportCountKey
 import kr.weit.roadyfoody.support.annotation.ServiceIntegrateTest
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
+import kr.weit.roadyfoody.user.repository.UserRepository
 import org.springframework.data.redis.core.RedisTemplate
 
 @ServiceIntegrateTest
 class AdminCommandServiceIntegrationTest(
+    @MockkBean private val userRepository: UserRepository,
     private val adminCommandService: AdminCommandService,
     private val redisTemplate: RedisTemplate<String, String>,
 ) : BehaviorSpec({
         given("이미 생성 횟수가 5인 회원이 있을 때") {
             val userKey = getFoodSpotsReportCountKey(TEST_USER_ID)
+            every { userRepository.existsById(TEST_USER_ID) } returns true
             redisTemplate.opsForValue().set(userKey, "5")
-
             `when`("그 회원의 생성 횟수를 1로 변경 요청하면") {
                 adminCommandService.updateUserDailyReportCount(TEST_USER_ID, 1)
-
                 then("redis 에 값이 변경되어야 한다.") {
                     val restReportCount = redisTemplate.opsForValue().get(userKey)
                     restReportCount shouldBe "1"

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceIntegrationTest.kt
@@ -1,0 +1,29 @@
+package kr.weit.roadyfoody.admin.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService.Companion.getFoodSpotsReportCountKey
+import kr.weit.roadyfoody.support.annotation.ServiceIntegrateTest
+import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
+import org.springframework.data.redis.core.RedisTemplate
+
+@ServiceIntegrateTest
+class AdminCommandServiceIntegrationTest(
+    private val adminCommandService: AdminCommandService,
+    private val redisTemplate: RedisTemplate<String, String>,
+) : BehaviorSpec({
+        given("이미 생성 횟수가 5인 회원이 있을 때") {
+            val userKey = getFoodSpotsReportCountKey(TEST_USER_ID)
+            redisTemplate.opsForValue().set(userKey, "5")
+
+            `when`("그 회원의 생성 횟수를 1로 변경 요청하면") {
+                adminCommandService.updateUserDailyReportCount(TEST_USER_ID, 1)
+
+                then("redis 에 값이 변경되어야 한다.") {
+                    val restReportCount = redisTemplate.opsForValue().get(userKey)
+                    restReportCount shouldBe "1"
+                }
+            }
+            redisTemplate.delete(userKey)
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
@@ -1,11 +1,13 @@
 package kr.weit.roadyfoody.admin.application.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kr.weit.roadyfoody.auth.fixture.TEST_ACCESS_TOKEN
 import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
+import kr.weit.roadyfoody.user.exception.UserNotFoundException
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository
@@ -26,6 +28,25 @@ class AdminCommandServiceTest :
                 then("UserAccessTokenResponse 를 반환한다.") {
                     val actual = adminCommandService.getUserAccessToken(TEST_USER_ID).accessToken
                     actual shouldBe TEST_ACCESS_TOKEN
+                }
+            }
+        }
+
+        given("updateUserDailyReportCount 테스트") {
+            `when`("유저 ID 와 일일 신고 횟수로 요청하면") {
+                every { userRepository.existsById(any()) } returns true
+                every { redisTemplate.opsForValue().set(any(), any()) } returns Unit
+                then("성공한다.") {
+                    adminCommandService.updateUserDailyReportCount(TEST_USER_ID, 1)
+                }
+            }
+
+            `when`("유저 ID 가 존재하지 않으면") {
+                every { userRepository.existsById(any()) } returns false
+                then("UserNotFoundException 이 발생한다.") {
+                    shouldThrow<UserNotFoundException> {
+                        adminCommandService.updateUserDailyReportCount(TEST_USER_ID, 1)
+                    }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
@@ -9,13 +9,15 @@ import kr.weit.roadyfoody.auth.security.jwt.JwtUtil
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository
+import org.springframework.data.redis.core.RedisTemplate
 import java.util.Optional
 
 class AdminCommandServiceTest :
     BehaviorSpec({
         val userRepository = mockk<UserRepository>()
         val jwtUtil = mockk<JwtUtil>()
-        val adminCommandService = AdminCommandService(userRepository, jwtUtil)
+        val redisTemplate = mockk<RedisTemplate<String, String>>()
+        val adminCommandService = AdminCommandService(userRepository, jwtUtil, redisTemplate)
 
         given("getUserAccessToken 테스트") {
             `when`("유저 ID 로 요청하면") {

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/application/service/AdminCommandServiceTest.kt
@@ -41,7 +41,7 @@ class AdminCommandServiceTest :
                 }
             }
 
-            `when`("유저 ID 가 존재하지 않으면") {
+            `when`("유저 ID 에 해당하는 유저가 존재하지 않으면") {
                 every { userRepository.existsById(any()) } returns false
                 then("UserNotFoundException 이 발생한다.") {
                     shouldThrow<UserNotFoundException> {

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
@@ -2,7 +2,11 @@ package kr.weit.roadyfoody.admin.presentation.api
 
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
 import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
 import kr.weit.roadyfoody.admin.application.service.AdminCommandService
 import kr.weit.roadyfoody.admin.application.service.AdminQueryService
 import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
@@ -13,6 +17,7 @@ import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(AdminController::class)
@@ -41,6 +46,59 @@ class AdminControllerTest(
                     mockMvc
                         .perform(get("$requestUrl/users/$TEST_USER_ID/token"))
                         .andExpect(status().isOk)
+                }
+            }
+
+            `when`("userId 가 0이나 음수로 요청하면") {
+                every { adminCommandService.getUserAccessToken(any()) } returns UserAccessTokenResponse(TEST_ACCESS_TOKEN)
+                then("400 상태코드를 반환한다.") {
+                    forAll(
+                        row(0),
+                        row(-1),
+                    ) { userId ->
+                        mockMvc
+                            .perform(get("$requestUrl/users/$userId/token"))
+                            .andExpect(status().isBadRequest)
+                    }
+                }
+            }
+        }
+
+        given("PUT $requestUrl/users/{userId}/daily-report-count 테스트") {
+            val dailyReportCount = 1
+
+            `when`("정상적으로 요청하면") {
+                every { adminCommandService.updateUserDailyReportCount(TEST_USER_ID, any()) } just runs
+                then("204 상태코드를 반환한다.") {
+                    mockMvc
+                        .perform(put("$requestUrl/users/$TEST_USER_ID/daily-report-count?dailyReportCount=$dailyReportCount"))
+                        .andExpect(status().isNoContent)
+                }
+            }
+
+            `when`("userId 가 0이나 음수로 요청하면") {
+                every { adminCommandService.updateUserDailyReportCount(any(), any()) } just runs
+
+                then("400 상태코드를 반환한다.") {
+                    forAll(
+                        row(0),
+                        row(-1),
+                    ) { userId ->
+                        mockMvc
+                            .perform(put("$requestUrl/users/$userId/daily-report-count?dailyReportCount=$dailyReportCount"))
+                            .andExpect(status().isBadRequest)
+                    }
+                }
+            }
+
+            `when`("dailyReportCount 가 음수로 요청하면") {
+                every { adminCommandService.updateUserDailyReportCount(TEST_USER_ID, -1) } just runs
+                val negativeDailyReportCount = -1
+
+                then("400 상태코드를 반환한다.") {
+                    mockMvc
+                        .perform(put("$requestUrl/users/$TEST_USER_ID/daily-report-count?dailyReportCount=$negativeDailyReportCount"))
+                        .andExpect(status().isBadRequest)
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
@@ -9,8 +9,6 @@ import kr.weit.roadyfoody.admin.dto.UserAccessTokenResponse
 import kr.weit.roadyfoody.admin.fixture.createTestSimpleUserInfoResponses
 import kr.weit.roadyfoody.auth.fixture.TEST_ACCESS_TOKEN
 import kr.weit.roadyfoody.support.annotation.ControllerTest
-import kr.weit.roadyfoody.user.exception.UserNotFoundException
-import kr.weit.roadyfoody.user.fixture.TEST_NONEXISTENT_ID
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.test.web.servlet.MockMvc
@@ -43,16 +41,6 @@ class AdminControllerTest(
                     mockMvc
                         .perform(get("$requestUrl/users/$TEST_USER_ID/token"))
                         .andExpect(status().isOk)
-                }
-            }
-
-            `when`("존재하지 않는 userId 로 요청하면") {
-                every { adminCommandService.getUserAccessToken(TEST_NONEXISTENT_ID) } throws
-                    UserNotFoundException("$TEST_NONEXISTENT_ID ID 의 사용자는 존재하지 않습니다.")
-                then("404 상태코드를 반환한다.") {
-                    mockMvc
-                        .perform(get("$requestUrl/users/$TEST_NONEXISTENT_ID/token"))
-                        .andExpect(status().isNotFound)
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/admin/presentation/api/AdminControllerTest.kt
@@ -66,7 +66,6 @@ class AdminControllerTest(
 
         given("PUT $requestUrl/users/{userId}/daily-report-count 테스트") {
             val dailyReportCount = 1
-
             `when`("정상적으로 요청하면") {
                 every { adminCommandService.updateUserDailyReportCount(TEST_USER_ID, any()) } just runs
                 then("204 상태코드를 반환한다.") {
@@ -78,7 +77,6 @@ class AdminControllerTest(
 
             `when`("userId 가 0이나 음수로 요청하면") {
                 every { adminCommandService.updateUserDailyReportCount(any(), any()) } just runs
-
                 then("400 상태코드를 반환한다.") {
                     forAll(
                         row(0),
@@ -94,7 +92,6 @@ class AdminControllerTest(
             `when`("dailyReportCount 가 음수로 요청하면") {
                 every { adminCommandService.updateUserDailyReportCount(TEST_USER_ID, -1) } just runs
                 val negativeDailyReportCount = -1
-
                 then("400 상태코드를 반환한다.") {
                     mockMvc
                         .perform(put("$requestUrl/users/$TEST_USER_ID/daily-report-count?dailyReportCount=$negativeDailyReportCount"))


### PR DESCRIPTION
### 개요
개발 시 편의를 위해 자정이 되기 전에도 유저의 리포트 생성 횟수를 다룰 수 있도록 API 를 생성합니다.

### 변경사항
- 유저 일일 리포트 생성 횟수 변경 API 및 테스트 작성

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-157) 


### 리뷰어에게 하고 싶은 말
모든 피드백 감사히 잘 받겠습니다!