### PR TITLE
ROFO-176 승급보상획득내역 테이블 추가 및 관련 변경 사항 적용

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/badge/domain/Badge.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/badge/domain/Badge.kt
@@ -1,0 +1,10 @@
+package kr.weit.roadyfoody.badge.domain
+
+enum class Badge(
+    val description: String,
+) {
+    BEGINNER("초심자"),
+    PRO("중수"),
+    SUPER("고수"),
+    EXPERT("초고수"),
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/badge/domain/UserPromotionRewardHistory.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/badge/domain/UserPromotionRewardHistory.kt
@@ -1,0 +1,42 @@
+package kr.weit.roadyfoody.badge.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.SequenceGenerator
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import kr.weit.roadyfoody.common.domain.BaseTimeEntity
+import kr.weit.roadyfoody.user.domain.User
+
+@Entity
+@Table(
+    name = "user_promotion_reward_histories",
+    uniqueConstraints = [
+        UniqueConstraint(name = "user_promotion_reward_histories_user_id_promotion_reward_idx", columnNames = ["user_id", "badge"]),
+    ],
+)
+@SequenceGenerator(
+    name = "USER_PROMOTION_REWARD_HISTORIES_SEQ_GENERATOR",
+    sequenceName = "USER_PROMOTION_REWARD_HISTORIES_SEQ",
+    initialValue = 1,
+    allocationSize = 1,
+)
+class UserPromotionRewardHistory(
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "USER_PROMOTION_REWARD_HISTORIES_SEQ_GENERATOR")
+    val id: Long = 0L,
+    @ManyToOne(fetch = FetchType.LAZY)
+    val user: User,
+    @Enumerated(EnumType.STRING)
+    val badge: Badge,
+) : BaseTimeEntity() {
+    companion object {
+        fun from(user: User): UserPromotionRewardHistory = UserPromotionRewardHistory(user = user, badge = user.badge)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/domain/User.kt
@@ -4,11 +4,15 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
+import kr.weit.roadyfoody.badge.domain.Badge
 import kr.weit.roadyfoody.common.domain.BaseModifiableEntity
 import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
@@ -16,7 +20,12 @@ import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX
 import kr.weit.roadyfoody.user.utils.NICKNAME_REGEX_DESC
 
 @Entity
-@Table(name = "users")
+@Table(
+    name = "users",
+    indexes = [
+        Index(name = "users_badge_idx", columnList = "badge"),
+    ],
+)
 @SequenceGenerator(name = "USERS_SEQ_GENERATOR", sequenceName = "USERS_SEQ", initialValue = 1, allocationSize = 1)
 class User(
     @Id
@@ -29,6 +38,8 @@ class User(
     var profile: Profile,
     @Column(nullable = false)
     var coin: Int,
+    @Enumerated(EnumType.STRING)
+    var badge: Badge,
 ) : BaseModifiableEntity() {
     init {
         require(NICKNAME_REGEX.matches(profile.nickname)) { NICKNAME_REGEX_DESC }
@@ -40,7 +51,8 @@ class User(
             nickname: String,
             profileImageName: String? = null,
             coin: Int = 0,
-        ): User = User(socialId = socialId, profile = Profile(nickname, profileImageName), coin = coin)
+            badge: Badge = Badge.BEGINNER,
+        ): User = User(socialId = socialId, profile = Profile(nickname, profileImageName), coin = coin, badge = badge)
     }
 
     fun decreaseCoin(minusCoin: Int): Int {
@@ -62,6 +74,10 @@ class User(
 
     fun changeProfileImageName(profileImageName: String? = null) {
         profile = profile.changeProfileImageName(profileImageName)
+    }
+
+    fun changeBadge(badge: Badge) {
+        this.badge = badge
     }
 }
 

--- a/src/main/resources/db/migration/V15__create_user_promotion_reward_histories.sql
+++ b/src/main/resources/db/migration/V15__create_user_promotion_reward_histories.sql
@@ -1,0 +1,26 @@
+ALTER TABLE users
+    ADD badge VARCHAR2(30) DEFAULT 'BEGINNER' NOT NULL;
+
+CREATE INDEX users_badge_idx ON users (badge);
+
+create
+    sequence user_promotion_reward_histories_seq start
+    with 1 increment by 1;
+
+CREATE TABLE user_promotion_reward_histories
+(
+    id               NUMERIC(19, 0) NOT NULL,
+    user_id          NUMERIC(19, 0) NOT NULL,
+    badge            VARCHAR2(30)   NOT NULL,
+    created_datetime TIMESTAMP(6)   NOT NULL
+);
+
+ALTER TABLE user_promotion_reward_histories
+    ADD CONSTRAINT user_promotion_reward_histories_pk PRIMARY KEY (id);
+
+ALTER TABLE user_promotion_reward_histories
+    ADD CONSTRAINT user_promotion_reward_histories_user_id_fk FOREIGN KEY (user_id) REFERENCES users (id);
+
+ALTER TABLE user_promotion_reward_histories
+    ADD CONSTRAINT user_promotion_reward_histories_user_id_badge_uk UNIQUE (user_id, badge);
+

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
@@ -1,5 +1,6 @@
 package kr.weit.roadyfoody.user.fixture
 
+import kr.weit.roadyfoody.badge.domain.Badge
 import kr.weit.roadyfoody.user.application.dto.UserNicknameRequest
 import kr.weit.roadyfoody.user.domain.Profile
 import kr.weit.roadyfoody.user.domain.SocialLoginType
@@ -26,6 +27,7 @@ fun createTestUser(
     socialId: String = TEST_USER_SOCIAL_ID,
     profileImageName: String? = "${TEST_USER_PROFILE_IMAGE_NAME}_$id",
     coin: Int = TEST_USER_COIN,
+    badge: Badge = Badge.BEGINNER,
 ) = User(
     id,
     socialId,
@@ -34,6 +36,7 @@ fun createTestUser(
         profileImageName,
     ),
     coin,
+    badge,
 )
 
 fun createTestUsers(size: Int = 5) = List(size) { createTestUser(it.toLong() + 1) }


### PR DESCRIPTION
### 개요
승급보상획득내역 테이블 및 users 테이블에 badge 컬럼을 추가합니다.

### 변경사항
- Badge Enum Class 작성
- 승급보상획득내역 테이블 추가 및 관련 변경 사항 적용


### 테스트
- 테스트 코드 추가여부 X
테이블, 도메인 엔티티 관련 작업이였습니다.

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-176) 


### 리뷰어에게 하고 싶은 말
모든 피드백 감사히 잘 받겠습니다.

<img width="1028" alt="스크린샷 2024-08-26 오후 7 49 48" src="https://github.com/user-attachments/assets/8f6da302-d788-4b6c-86a6-0eb244277a8f">
