### PR TITLE
[ROFO-182] 리뷰 랭킹 구현, 조회 api 

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/dto/ReportDtos.kt
@@ -408,10 +408,3 @@ data class ReviewAggregatedInfoResponse(
         reviewCount ?: 0,
     )
 }
-
-data class UserReportCount(
-    @Schema(description = "유저 닉네임", example = "로디푸디유저")
-    val userNickname: String,
-    @Schema(description = "유저가 작성한 Report 개수", example = "1")
-    val reportCount: Long,
-)

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandService.kt
@@ -5,7 +5,6 @@ import kr.weit.roadyfoody.common.exception.ErrorCode
 import kr.weit.roadyfoody.common.exception.RoadyFoodyBadRequestException
 import kr.weit.roadyfoody.foodSpots.application.dto.FoodSpotsUpdateRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
 import kr.weit.roadyfoody.foodSpots.application.service.event.ReportErrorCompensatingTxSync
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsFoodCategory
@@ -38,7 +37,6 @@ import kr.weit.roadyfoody.rewards.domain.RewardType
 import kr.weit.roadyfoody.rewards.domain.Rewards
 import kr.weit.roadyfoody.user.application.service.UserCommandService
 import kr.weit.roadyfoody.user.domain.User
-import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
@@ -54,7 +52,6 @@ import java.time.ZoneId
 import java.util.Date
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.TimeUnit
 
 @Service
 class FoodSpotsCommandService(
@@ -82,9 +79,6 @@ class FoodSpotsCommandService(
         const val FOOD_SPOTS_REPORT_LIMIT_COUNT = 5
 
         fun getFoodSpotsReportCountKey(userId: Long) = "$FOOD_SPOTS_REPORT_LIMIT_PREFIX$userId"
-
-        private const val REPORT_RANKING_KEY = "rofo:user-report-ranking"
-        private const val REPORT_RANKING_UPDATE_LOCK = "updateReportRankingLock"
     }
 
     @DistributedLock(lockName = USER_ENTITY_LOCK_KEY, identifier = "user")
@@ -442,44 +436,5 @@ class FoodSpotsCommandService(
                     imageService.remove(it.fileName)
                 }, executor)
             }.forEach { it.join() }
-    }
-
-    fun getReportRanking(size: Long): List<UserReportCount> {
-        val typedTuple =
-            redisTemplate.opsForZSet().reverseRangeWithScores(
-                REPORT_RANKING_KEY,
-                0,
-                size - 1,
-            ) ?: emptySet()
-
-        return typedTuple.map { tuple ->
-            val userNickname = tuple.value ?: ""
-            val score = tuple.score ?: 0.0
-
-            UserReportCount(
-                userNickname = userNickname,
-                reportCount = score.toLong(),
-            )
-        }
-    }
-
-    @Scheduled(cron = "0 0 5 * * *")
-    fun updateReportRanking() {
-        val lock: RLock = redissonClient.getLock(REPORT_RANKING_UPDATE_LOCK)
-        if (lock.tryLock(0, 10, TimeUnit.MINUTES)) {
-            redisTemplate.delete(REPORT_RANKING_KEY)
-
-            val userReports = foodSpotsHistoryRepository.findAllUserReportCount()
-
-            userReports.forEach {
-                redisTemplate
-                    .opsForZSet()
-                    .add(
-                        REPORT_RANKING_KEY,
-                        it.userNickname,
-                        it.reportCount.toDouble(),
-                    )
-            }
-        }
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepository.kt
@@ -1,12 +1,12 @@
 package kr.weit.roadyfoody.foodSpots.repository
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
 import kr.weit.roadyfoody.foodSpots.exception.FoodSpotsHistoryNotFoundException
 import kr.weit.roadyfoody.global.utils.findList
 import kr.weit.roadyfoody.global.utils.getSlice
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.user.domain.Profile
 import kr.weit.roadyfoody.user.domain.User
 import org.springframework.data.domain.Pageable
@@ -39,7 +39,7 @@ interface CustomFoodSpotsHistoryRepository {
         lastId: Long?,
     ): Slice<FoodSpotsHistory>
 
-    fun findAllUserReportCount(): List<UserReportCount>
+    fun findAllUserReportCount(): List<UserRanking>
 }
 
 class CustomFoodSpotsHistoryRepositoryImpl(
@@ -65,7 +65,7 @@ class CustomFoodSpotsHistoryRepositoryImpl(
         }
     }
 
-    override fun findAllUserReportCount(): List<UserReportCount> =
+    override fun findAllUserReportCount(): List<UserRanking> =
         kotlinJdslJpqlExecutor
             .findList {
                 val userIdPath = path(FoodSpotsHistory::user).path(User::id)
@@ -73,7 +73,7 @@ class CustomFoodSpotsHistoryRepositoryImpl(
                 val historyIdPath = path(FoodSpotsHistory::id)
                 val createdAtPath = path(FoodSpotsHistory::createdDateTime)
 
-                selectNew<UserReportCount>(
+                selectNew<UserRanking>(
                     userNicknamePath,
                     count(historyIdPath),
                 ).from(entity(FoodSpotsHistory::class))

--- a/src/main/kotlin/kr/weit/roadyfoody/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/config/AsyncConfig.kt
@@ -1,0 +1,27 @@
+package kr.weit.roadyfoody.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean(name = ["asyncTask"])
+    fun threadPoolTaskExecutor(): Executor {
+        val taskExecutor = ThreadPoolTaskExecutor()
+        taskExecutor.corePoolSize = CORE_POOL_SIZE
+        taskExecutor.maxPoolSize = MAX_POOL_SIZE
+        taskExecutor.queueCapacity = QUEUE_CAPACITY
+        taskExecutor.setThreadNamePrefix("async-thread-")
+        return taskExecutor
+    }
+
+    companion object {
+        private const val CORE_POOL_SIZE = 5
+        private const val MAX_POOL_SIZE = 10
+        private const val QUEUE_CAPACITY = 30
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/global/config/SchedulingConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/config/SchedulingConfig.kt
@@ -1,8 +1,20 @@
 package kr.weit.roadyfoody.global.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.SchedulingConfigurer
+import org.springframework.scheduling.config.ScheduledTaskRegistrar
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 @EnableScheduling
 @Configuration
-class SchedulingConfig
+class SchedulingConfig : SchedulingConfigurer {
+    override fun configureTasks(taskRegistrar: ScheduledTaskRegistrar) {
+        taskRegistrar.setScheduler(taskExecutor())
+    }
+
+    @Bean
+    fun taskExecutor(): Executor = Executors.newScheduledThreadPool(10)
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -10,6 +10,7 @@ import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.concurrent.TimeUnit
@@ -21,6 +22,7 @@ class RankingCommandService(
     private val foodSpotsHistoryRepository: FoodSpotsHistoryRepository,
     private val reviewRepository: FoodSpotsReviewRepository,
 ) {
+    @Async("asyncTask")
     @Scheduled(cron = "0 0 5 * * *")
     fun updateReportRanking() {
         updateRanking(
@@ -30,6 +32,7 @@ class RankingCommandService(
         )
     }
 
+    @Async("asyncTask")
     @Scheduled(cron = "0 0 5 * * *")
     fun updateReviewRanking() {
         updateRanking(

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -61,7 +61,7 @@ class RankingCommandService(
                         .add(
                             key,
                             it.userNickname,
-                            it.score.toDouble(),
+                            it.total.toDouble(),
                         )
                 }
             }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -1,0 +1,37 @@
+package kr.weit.roadyfoody.ranking.application.service
+
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
+import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_KEY
+import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_UPDATE_LOCK
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
+import java.util.concurrent.TimeUnit
+
+class RankingCommandService(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val redissonClient: RedissonClient,
+    private val foodSpotsHistoryRepository: FoodSpotsHistoryRepository,
+) {
+    @Scheduled(cron = "0 0 5 * * *")
+    fun updateReportRanking() {
+        val lock: RLock = redissonClient.getLock(REPORT_RANKING_UPDATE_LOCK)
+
+        if (lock.tryLock(0, 10, TimeUnit.MINUTES)) {
+            redisTemplate.delete(REPORT_RANKING_KEY)
+
+            val userReports = foodSpotsHistoryRepository.findAllUserReportCount()
+
+            userReports.forEach {
+                redisTemplate
+                    .opsForZSet()
+                    .add(
+                        REPORT_RANKING_KEY,
+                        it.userNickname,
+                        it.reportCount.toDouble(),
+                    )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -1,8 +1,12 @@
 package kr.weit.roadyfoody.ranking.application.service
 
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_KEY
 import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_UPDATE_LOCK
+import kr.weit.roadyfoody.ranking.utils.REVIEW_RANKING_KEY
+import kr.weit.roadyfoody.ranking.utils.REVIEW_RANKING_UPDATE_LOCK
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
@@ -13,6 +17,7 @@ class RankingCommandService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val redissonClient: RedissonClient,
     private val foodSpotsHistoryRepository: FoodSpotsHistoryRepository,
+    private val reviewRepository: FoodSpotsReviewRepository,
 ) {
     @Scheduled(cron = "0 0 5 * * *")
     fun updateReportRanking() {
@@ -29,7 +34,52 @@ class RankingCommandService(
                     .add(
                         REPORT_RANKING_KEY,
                         it.userNickname,
-                        it.reportCount.toDouble(),
+                        it.score.toDouble(),
+                    )
+            }
+        }
+    }
+
+    @Scheduled(cron = "0 0 5 * * *")
+    fun updateReviewRanking() {
+        val lock: RLock = redissonClient.getLock(REVIEW_RANKING_UPDATE_LOCK)
+
+        if (lock.tryLock(0, 10, TimeUnit.MINUTES)) {
+            redisTemplate.delete(REVIEW_RANKING_KEY)
+
+            val userReviews = reviewRepository.findAllUserReviewCount()
+
+            userReviews.forEach {
+                redisTemplate
+                    .opsForZSet()
+                    .add(
+                        REVIEW_RANKING_KEY,
+                        it.userNickname,
+                        it.score.toDouble(),
+                    )
+            }
+        }
+    }
+
+    private fun userRanking(
+        lockName: String,
+        key: String,
+        dataProvider: () -> List<UserRanking>,
+    ) {
+        val lock: RLock = redissonClient.getLock(lockName)
+
+        if (lock.tryLock(0, 10, TimeUnit.MINUTES)) {
+            redisTemplate.delete(key)
+
+            val userReviews = dataProvider()
+
+            userReviews.forEach {
+                redisTemplate
+                    .opsForZSet()
+                    .add(
+                        key,
+                        it.userNickname,
+                        it.score.toDouble(),
                     )
             }
         }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -10,7 +10,6 @@ import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
@@ -34,7 +33,6 @@ class RankingCommandService(
         )
     }
 
-    @Async
     @Scheduled(cron = "0 0 5 * * *")
     fun updateReviewRanking() {
         updateRanking(

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -1,7 +1,8 @@
 package kr.weit.roadyfoody.ranking.application.service
 
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_KEY
+import kr.weit.roadyfoody.ranking.utils.REVIEW_RANKING_KEY
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 
@@ -9,21 +10,28 @@ import org.springframework.stereotype.Service
 class RankingQueryService(
     private val redisTemplate: RedisTemplate<String, String>,
 ) {
-    fun getReportRanking(size: Long): List<UserReportCount> {
+    fun getReportRanking(size: Long): List<UserRanking> = getRanking(size, REPORT_RANKING_KEY)
+
+    fun getReviewRanking(size: Long): List<UserRanking> = getRanking(size, REVIEW_RANKING_KEY)
+
+    private fun getRanking(
+        size: Long,
+        key: String,
+    ): List<UserRanking> {
         val typedTuple =
             redisTemplate.opsForZSet().reverseRangeWithScores(
-                REPORT_RANKING_KEY,
+                key,
                 0,
                 size - 1,
             ) ?: emptySet()
 
         return typedTuple.map { tuple ->
             val userNickname = tuple.value ?: ""
-            val reportCount = tuple.score ?: 0.0
+            val score = tuple.score ?: 0.0
 
-            UserReportCount(
+            UserRanking(
                 userNickname = userNickname,
-                reportCount = reportCount.toLong(),
+                score = score.toLong(),
             )
         }
     }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -27,11 +27,11 @@ class RankingQueryService(
 
         return typedTuple.map { tuple ->
             val userNickname = tuple.value ?: ""
-            val score = tuple.score ?: 0.0
+            val total = tuple.score ?: 0.0
 
             UserRanking(
                 userNickname = userNickname,
-                score = score.toLong(),
+                total = total.toLong(),
             )
         }
     }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -1,0 +1,30 @@
+package kr.weit.roadyfoody.ranking.application.service
+
+import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
+import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_KEY
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RankingQueryService(
+    private val redisTemplate: RedisTemplate<String, String>,
+) {
+    fun getReportRanking(size: Long): List<UserReportCount> {
+        val typedTuple =
+            redisTemplate.opsForZSet().reverseRangeWithScores(
+                REPORT_RANKING_KEY,
+                0,
+                size - 1,
+            ) ?: emptySet()
+
+        return typedTuple.map { tuple ->
+            val userNickname = tuple.value ?: ""
+            val reportCount = tuple.score ?: 0.0
+
+            UserReportCount(
+                userNickname = userNickname,
+                reportCount = reportCount.toLong(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -1,29 +1,47 @@
 package kr.weit.roadyfoody.ranking.application.service
 
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
 import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.ranking.utils.REPORT_RANKING_KEY
 import kr.weit.roadyfoody.ranking.utils.REVIEW_RANKING_KEY
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 
 @Service
 class RankingQueryService(
     private val redisTemplate: RedisTemplate<String, String>,
+    private val foodSpotsHistoryRepository: FoodSpotsHistoryRepository,
+    private val reviewRepository: FoodSpotsReviewRepository,
 ) {
-    fun getReportRanking(size: Long): List<UserRanking> = getRanking(size, REPORT_RANKING_KEY)
+    fun getReportRanking(size: Long): List<UserRanking> =
+        getRanking(
+            size = size,
+            key = REPORT_RANKING_KEY,
+            dataProvider = foodSpotsHistoryRepository::findAllUserReportCount,
+        )
 
-    fun getReviewRanking(size: Long): List<UserRanking> = getRanking(size, REVIEW_RANKING_KEY)
+    fun getReviewRanking(size: Long): List<UserRanking> =
+        getRanking(
+            size = size,
+            key = REVIEW_RANKING_KEY,
+            dataProvider = reviewRepository::findAllUserReviewCount,
+        )
 
     private fun getRanking(
         size: Long,
         key: String,
+        dataProvider: () -> List<UserRanking>,
     ): List<UserRanking> {
         val typedTuple =
             redisTemplate.opsForZSet().reverseRangeWithScores(
                 key,
                 0,
                 size - 1,
-            ) ?: emptySet()
+            ) ?: return fallback(
+                key = key,
+                dataProvider = dataProvider,
+            )
 
         return typedTuple.map { tuple ->
             val userNickname = tuple.value ?: ""
@@ -34,5 +52,23 @@ class RankingQueryService(
                 total = total.toLong(),
             )
         }
+    }
+
+    private fun fallback(
+        key: String,
+        dataProvider: () -> List<UserRanking>,
+    ): List<UserRanking> {
+        val userRanking = dataProvider()
+
+        userRanking.forEach {
+            redisTemplate
+                .opsForZSet()
+                .add(
+                    key,
+                    it.userNickname,
+                    it.total.toDouble(),
+                )
+        }
+        return userRanking
     }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/dto/UserRanking.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/dto/UserRanking.kt
@@ -1,0 +1,10 @@
+package kr.weit.roadyfoody.ranking.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UserRanking(
+    @Schema(description = "유저 닉네임", example = "로디푸디유저")
+    val userNickname: String,
+    @Schema(description = "총합수 또는 점수", example = "1")
+    val score: Long,
+)

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/dto/UserRanking.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/dto/UserRanking.kt
@@ -5,6 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class UserRanking(
     @Schema(description = "유저 닉네임", example = "로디푸디유저")
     val userNickname: String,
-    @Schema(description = "총합수 또는 점수", example = "1")
-    val score: Long,
+    @Schema(description = "총합수", example = "1")
+    val total: Long,
 )

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingController.kt
@@ -2,7 +2,7 @@ package kr.weit.roadyfoody.ranking.presentation.api
 
 import jakarta.validation.constraints.Positive
 import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
-import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService
+import kr.weit.roadyfoody.ranking.application.service.RankingQueryService
 import kr.weit.roadyfoody.ranking.presentation.spec.RankingControllerSpec
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/ranking")
 class RankingController(
-    private val foodSpotsCommandService: FoodSpotsCommandService,
+    private val rankingQueryService: RankingQueryService,
 ) : RankingControllerSpec {
     @GetMapping("/report")
     override fun getReportRanking(
         @Positive(message = "size는 양수여야 합니다.")
         @RequestParam(defaultValue = "10")
         size: Long,
-    ): List<UserReportCount> = foodSpotsCommandService.getReportRanking(size)
+    ): List<UserReportCount> = rankingQueryService.getReportRanking(size)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingController.kt
@@ -1,8 +1,8 @@
 package kr.weit.roadyfoody.ranking.presentation.api
 
 import jakarta.validation.constraints.Positive
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
 import kr.weit.roadyfoody.ranking.application.service.RankingQueryService
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.ranking.presentation.spec.RankingControllerSpec
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,5 +19,12 @@ class RankingController(
         @Positive(message = "size는 양수여야 합니다.")
         @RequestParam(defaultValue = "10")
         size: Long,
-    ): List<UserReportCount> = rankingQueryService.getReportRanking(size)
+    ): List<UserRanking> = rankingQueryService.getReportRanking(size)
+
+    @GetMapping("/review")
+    override fun getReviewRanking(
+        @Positive(message = "size는 양수여야 합니다.")
+        @RequestParam(defaultValue = "10")
+        size: Long,
+    ): List<UserRanking> = rankingQueryService.getReviewRanking(size)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/spec/RankingControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/spec/RankingControllerSpec.kt
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Positive
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestParam
 
@@ -24,7 +24,7 @@ interface RankingControllerSpec {
                         mediaType = MediaType.APPLICATION_JSON_VALUE,
                         schema =
                             Schema(
-                                implementation = UserReportCount::class,
+                                implementation = UserRanking::class,
                             ),
                     ),
                 ],
@@ -36,5 +36,29 @@ interface RankingControllerSpec {
         @Positive(message = "size는 양수여야 합니다.")
         @RequestParam(defaultValue = "10")
         size: Long,
-    ): List<UserReportCount>
+    ): List<UserRanking>
+
+    @Operation(
+        description = "리뷰 랭킹 조회 API",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "리뷰 랭킹 조회 성공",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema =
+                            Schema(
+                                implementation = UserRanking::class,
+                            ),
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getReviewRanking(
+        @Positive(message = "size는 양수여야 합니다.")
+        @RequestParam(defaultValue = "10")
+        size: Long,
+    ): List<UserRanking>
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/spec/RankingControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/presentation/spec/RankingControllerSpec.kt
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Positive
+import kr.weit.roadyfoody.common.exception.ErrorCode
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 import kr.weit.roadyfoody.ranking.dto.UserRanking
 import org.springframework.http.MediaType
@@ -13,6 +15,11 @@ import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = SwaggerTag.RANKING)
 interface RankingControllerSpec {
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.SIZE_NON_POSITIVE,
+        ],
+    )
     @Operation(
         description = "리포트 랭킹 조회 API",
         responses = [
@@ -38,6 +45,11 @@ interface RankingControllerSpec {
         size: Long,
     ): List<UserRanking>
 
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.SIZE_NON_POSITIVE,
+        ],
+    )
     @Operation(
         description = "리뷰 랭킹 조회 API",
         responses = [

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/utils/RankingConstans.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/utils/RankingConstans.kt
@@ -1,4 +1,6 @@
 package kr.weit.roadyfoody.ranking.utils
 
 const val REPORT_RANKING_KEY = "rofo:user-report-ranking"
+const val REVIEW_RANKING_KEY = "rofo:user-review-ranking"
 const val REPORT_RANKING_UPDATE_LOCK = "updateReportRankingLock"
+const val REVIEW_RANKING_UPDATE_LOCK = "updateReviewRankingLock"

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/utils/RankingConstans.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/utils/RankingConstans.kt
@@ -1,0 +1,4 @@
+package kr.weit.roadyfoody.ranking.utils
+
+const val REPORT_RANKING_KEY = "rofo:user-report-ranking"
+const val REPORT_RANKING_UPDATE_LOCK = "updateReportRankingLock"

--- a/src/main/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepository.kt
@@ -6,7 +6,6 @@ import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sortable
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import kr.weit.roadyfoody.foodSpots.application.dto.ReviewAggregatedInfoResponse
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
-import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
 import kr.weit.roadyfoody.global.utils.findList
 import kr.weit.roadyfoody.global.utils.getSlice
 import kr.weit.roadyfoody.ranking.dto.UserRanking
@@ -106,7 +105,7 @@ class CustomFoodSpotsReviewRepositoryImpl(
                 val userIdPath = path(FoodSpotsReview::user).path(User::id)
                 val userNicknamePath = path(FoodSpotsReview::user).path(User::profile).path(Profile::nickname)
                 val reviewIdPath = path(FoodSpotsReview::id)
-                val createdAtPath = path(FoodSpotsHistory::createdDateTime)
+                val createdAtPath = path(FoodSpotsReview::createdDateTime)
 
                 selectNew<UserRanking>(
                     userNicknamePath,
@@ -115,7 +114,7 @@ class CustomFoodSpotsReviewRepositoryImpl(
                     .groupBy(userIdPath, userNicknamePath)
                     .orderBy(
                         count(reviewIdPath).desc(),
-                        createdAtPath.asc(),
+                        max(createdAtPath).asc(),
                     )
             }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/rewards/presentation/spec/RewardsControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/rewards/presentation/spec/RewardsControllerSpec.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import kr.weit.roadyfoody.auth.security.LoginUser
 import kr.weit.roadyfoody.common.dto.SliceResponse
+import kr.weit.roadyfoody.common.exception.ErrorCode
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
 import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
 import kr.weit.roadyfoody.rewards.application.dto.RewardsResponse
 import kr.weit.roadyfoody.user.domain.User
@@ -13,6 +15,11 @@ import org.springframework.data.web.PageableDefault
 
 @Tag(name = SwaggerTag.REWARDS)
 interface RewardsControllerSpec {
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.SIZE_NON_POSITIVE,
+        ],
+    )
     @Operation(
         description = "유저의 리워드 리스트 조회 API",
         responses = [

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/application/service/FoodSpotsCommandServiceTest.kt
@@ -44,7 +44,6 @@ import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpotsUpdateRequestFrom
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportFoodCategory
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportOperationHours
 import kr.weit.roadyfoody.foodSpots.fixture.createTestReportRequest
-import kr.weit.roadyfoody.foodSpots.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.foodSpots.repository.FoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsFoodCategoryRepository
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
@@ -62,14 +61,11 @@ import kr.weit.roadyfoody.user.fixture.TEST_OTHER_USER_ID
 import kr.weit.roadyfoody.user.fixture.TEST_USER_ID
 import kr.weit.roadyfoody.user.fixture.createTestUser
 import kr.weit.roadyfoody.user.repository.UserRepository
-import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
-import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.Optional
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.TimeUnit
 
 class FoodSpotsCommandServiceTest :
     BehaviorSpec(
@@ -683,73 +679,6 @@ class FoodSpotsCommandServiceTest :
                         verify(exactly = 1) {
                             foodSpotsHistoryRepository.deleteById(any())
                         }
-                    }
-                }
-            }
-
-            given("updateReportRanking 테스트") {
-                val mockLock = mockk<RLock>()
-                val zSetOperations = mockk<ZSetOperations<String, String>>()
-                val mockTypedTuple: Set<ZSetOperations.TypedTuple<String>> =
-                    setOf(
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user1"
-                            every { score } returns 10.0
-                        },
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user2"
-                            every { score } returns 5.0
-                        },
-                    )
-
-                every { redissonClient.getLock(any<String>()) } returns mockLock
-
-                `when`("Lock을 획득한 경우") {
-                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns true
-
-                    every { redisTemplate.delete("rofo:user-report-ranking") } returns true
-                    every { foodSpotsHistoryRepository.findAllUserReportCount() } returns createUserRankingResponse()
-                    every { redisTemplate.opsForZSet() } returns zSetOperations
-                    every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns mockTypedTuple
-                    every { zSetOperations.add("rofo:user-report-ranking", "existentNick", 10.0) } returns true
-
-                    then("레디스의 데이터가 정상적으로 업데이트된다.") {
-                        foodSpotsCommandService.updateReportRanking()
-                        verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
-                    }
-                }
-
-                `when`("Lock을 획득하지 못한 경우") {
-                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns false
-
-                    then("레디스의 데이터가 업데이트되지 않는다.") {
-                        foodSpotsCommandService.updateReportRanking()
-                        verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
-                    }
-                }
-            }
-
-            given("getReportRanking 테스트") {
-                val zSetOperations = mockk<ZSetOperations<String, String>>()
-                val typedTupleSet =
-                    setOf(
-                        mockk<ZSetOperations.TypedTuple<String>> {
-                            every { value } returns "user1"
-                            every { score } returns 10.0
-                        },
-                        mockk<ZSetOperations.TypedTuple<String>> {
-                            every { value } returns "user2"
-                            every { score } returns 20.0
-                        },
-                    )
-
-                `when`("레디스의 데이터를 조회한 경우") {
-                    every { redisTemplate.opsForZSet() } returns zSetOperations
-                    every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns typedTupleSet
-
-                    then("리포트 랭킹이 조회된다.") {
-                        foodSpotsCommandService.getReportRanking(10)
-                        verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -14,7 +14,6 @@ import kr.weit.roadyfoody.foodSpots.application.dto.ReportOperationHoursResponse
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportPhotoResponse
 import kr.weit.roadyfoody.foodSpots.application.dto.ReportRequest
 import kr.weit.roadyfoody.foodSpots.application.dto.ReviewAggregatedInfoResponse
-import kr.weit.roadyfoody.foodSpots.application.dto.UserReportCount
 import kr.weit.roadyfoody.foodSpots.domain.DayOfWeek
 import kr.weit.roadyfoody.foodSpots.domain.FoodCategory
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
@@ -28,6 +27,7 @@ import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.domain.ReportType
 import kr.weit.roadyfoody.foodSpots.utils.FOOD_SPOTS_NAME_MAX_LENGTH
 import kr.weit.roadyfoody.global.utils.CoordinateUtils
+import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponse
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponses
@@ -462,11 +462,11 @@ fun createTestAggregatedInfoResponse(): ReviewAggregatedInfoResponse =
 
 fun createUserReportCountResponse(
     user: User = createTestUser(),
-    reportCount: Long = 10,
-): UserReportCount =
-    UserReportCount(
+    score: Long = 10,
+): UserRanking =
+    UserRanking(
         userNickname = user.profile.nickname,
-        reportCount = reportCount,
+        score = score,
     )
 
-fun createUserRankingResponse(): List<UserReportCount> = listOf(createUserReportCountResponse())
+fun createUserRankingResponse(): List<UserRanking> = listOf(createUserReportCountResponse())

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -462,11 +462,11 @@ fun createTestAggregatedInfoResponse(): ReviewAggregatedInfoResponse =
 
 fun createCountResponse(
     user: User = createTestUser(),
-    score: Long = 10,
+    total: Long = 10,
 ): UserRanking =
     UserRanking(
         userNickname = user.profile.nickname,
-        score = score,
+        total = total,
     )
 
 fun createUserRankingResponse(): List<UserRanking> = listOf(createCountResponse())

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -460,7 +460,7 @@ fun createTestAggregatedInfoResponse(): ReviewAggregatedInfoResponse =
         TEST_REVIEW_COUNT,
     )
 
-fun createUserReportCountResponse(
+fun createCountResponse(
     user: User = createTestUser(),
     score: Long = 10,
 ): UserRanking =
@@ -469,4 +469,4 @@ fun createUserReportCountResponse(
         score = score,
     )
 
-fun createUserRankingResponse(): List<UserRanking> = listOf(createUserReportCountResponse())
+fun createUserRankingResponse(): List<UserRanking> = listOf(createCountResponse())

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/fixture/FoodSpotsFixture.kt
@@ -27,7 +27,6 @@ import kr.weit.roadyfoody.foodSpots.domain.ReportOperationHours
 import kr.weit.roadyfoody.foodSpots.domain.ReportType
 import kr.weit.roadyfoody.foodSpots.utils.FOOD_SPOTS_NAME_MAX_LENGTH
 import kr.weit.roadyfoody.global.utils.CoordinateUtils
-import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.search.foodSpots.domain.SearchCoinCache
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponse
 import kr.weit.roadyfoody.search.foodSpots.dto.FoodSpotsSearchResponses
@@ -459,14 +458,3 @@ fun createTestAggregatedInfoResponse(): ReviewAggregatedInfoResponse =
         TEST_AVERAGE_RATE,
         TEST_REVIEW_COUNT,
     )
-
-fun createCountResponse(
-    user: User = createTestUser(),
-    total: Long = 10,
-): UserRanking =
-    UserRanking(
-        userNickname = user.profile.nickname,
-        total = total,
-    )
-
-fun createUserRankingResponse(): List<UserRanking> = listOf(createCountResponse())

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepositoryTest.kt
@@ -131,16 +131,16 @@ class FoodSpotsHistoryRepositoryTest(
                 val userReportCounts = foodSpotsHistoryRepository.findAllUserReportCount()
                 userReportCounts.size shouldBe 4
                 userReportCounts[0].userNickname shouldBe "existentNick2"
-                userReportCounts[0].reportCount shouldBe 3
+                userReportCounts[0].score shouldBe 3
 
                 userReportCounts[1].userNickname shouldBe "existentNick"
-                userReportCounts[1].reportCount shouldBe 2
+                userReportCounts[1].score shouldBe 2
 
                 userReportCounts[2].userNickname shouldBe "existentNick3"
-                userReportCounts[2].reportCount shouldBe 2
+                userReportCounts[2].score shouldBe 2
 
                 userReportCounts[3].userNickname shouldBe "existentNick4"
-                userReportCounts[3].reportCount shouldBe 1
+                userReportCounts[3].score shouldBe 1
             }
         }
     })

--- a/src/test/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/foodSpots/repository/FoodSpotsHistoryRepositoryTest.kt
@@ -131,16 +131,16 @@ class FoodSpotsHistoryRepositoryTest(
                 val userReportCounts = foodSpotsHistoryRepository.findAllUserReportCount()
                 userReportCounts.size shouldBe 4
                 userReportCounts[0].userNickname shouldBe "existentNick2"
-                userReportCounts[0].score shouldBe 3
+                userReportCounts[0].total shouldBe 3
 
                 userReportCounts[1].userNickname shouldBe "existentNick"
-                userReportCounts[1].score shouldBe 2
+                userReportCounts[1].total shouldBe 2
 
                 userReportCounts[2].userNickname shouldBe "existentNick3"
-                userReportCounts[2].score shouldBe 2
+                userReportCounts[2].total shouldBe 2
 
                 userReportCounts[3].userNickname shouldBe "existentNick4"
-                userReportCounts[3].score shouldBe 1
+                userReportCounts[3].total shouldBe 1
             }
         }
     })

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
@@ -11,6 +11,7 @@ import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ZSetOperations
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 
 class RankingCommandServiceTest :
@@ -20,13 +21,19 @@ class RankingCommandServiceTest :
             val redissonClient = mockk<RedissonClient>()
             val foodSpotsHistoryRepository = mockk<FoodSpotsHistoryRepository>()
             val reviewRepository = mockk<FoodSpotsReviewRepository>()
+            val executor = mockk<ExecutorService>()
             val rankingCommandService =
                 RankingCommandService(
                     redisTemplate,
                     redissonClient,
                     foodSpotsHistoryRepository,
                     reviewRepository,
+                    executor,
                 )
+
+            every { executor.execute(any()) } answers {
+                firstArg<Runnable>().run()
+            }
 
             given("updateReportRanking 테스트") {
                 val mockLock = mockk<RLock>()
@@ -66,6 +73,48 @@ class RankingCommandServiceTest :
                     then("레디스의 데이터가 업데이트되지 않는다.") {
                         rankingCommandService.updateReportRanking()
                         verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
+                    }
+                }
+            }
+
+            given("updateReviewRanking 테스트") {
+                val mockLock = mockk<RLock>()
+                val zSetOperations = mockk<ZSetOperations<String, String>>()
+                val mockTypedTuple: Set<ZSetOperations.TypedTuple<String>> =
+                    setOf(
+                        mockk<ZSetOperations.TypedTuple<String>>().apply {
+                            every { value } returns "user1"
+                            every { score } returns 10.0
+                        },
+                        mockk<ZSetOperations.TypedTuple<String>>().apply {
+                            every { value } returns "user2"
+                            every { score } returns 5.0
+                        },
+                    )
+
+                every { redissonClient.getLock(any<String>()) } returns mockLock
+
+                `when`("Lock을 획득한 경우") {
+                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns true
+
+                    every { redisTemplate.delete("rofo:user-review-ranking") } returns true
+                    every { reviewRepository.findAllUserReviewCount() } returns createUserRankingResponse()
+                    every { redisTemplate.opsForZSet() } returns zSetOperations
+                    every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns mockTypedTuple
+                    every { zSetOperations.add("rofo:user-review-ranking", "existentNick", 10.0) } returns true
+
+                    then("레디스의 데이터가 정상적으로 업데이트된다.") {
+                        rankingCommandService.updateReviewRanking()
+                        verify(exactly = 1) { reviewRepository.findAllUserReviewCount() }
+                    }
+                }
+
+                `when`("Lock을 획득하지 못한 경우") {
+                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns false
+
+                    then("레디스의 데이터가 업데이트되지 않는다.") {
+                        rankingCommandService.updateReviewRanking()
+                        verify(exactly = 1) { reviewRepository.findAllUserReviewCount() }
                     }
                 }
             }

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
@@ -1,0 +1,70 @@
+package kr.weit.roadyfoody.ranking.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.weit.roadyfoody.foodSpots.fixture.createUserRankingResponse
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
+import java.util.concurrent.TimeUnit
+
+class RankingCommandServiceTest :
+    BehaviorSpec(
+        {
+            val redisTemplate = mockk<RedisTemplate<String, String>>()
+            val redissonClient = mockk<RedissonClient>()
+            val foodSpotsHistoryRepository = mockk<FoodSpotsHistoryRepository>()
+            val rankingCommandService =
+                RankingCommandService(
+                    redisTemplate,
+                    redissonClient,
+                    foodSpotsHistoryRepository,
+                )
+
+            given("updateReportRanking 테스트") {
+                val mockLock = mockk<RLock>()
+                val zSetOperations = mockk<ZSetOperations<String, String>>()
+                val mockTypedTuple: Set<ZSetOperations.TypedTuple<String>> =
+                    setOf(
+                        mockk<ZSetOperations.TypedTuple<String>>().apply {
+                            every { value } returns "user1"
+                            every { score } returns 10.0
+                        },
+                        mockk<ZSetOperations.TypedTuple<String>>().apply {
+                            every { value } returns "user2"
+                            every { score } returns 5.0
+                        },
+                    )
+
+                every { redissonClient.getLock(any<String>()) } returns mockLock
+
+                `when`("Lock을 획득한 경우") {
+                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns true
+
+                    every { redisTemplate.delete("rofo:user-report-ranking") } returns true
+                    every { foodSpotsHistoryRepository.findAllUserReportCount() } returns createUserRankingResponse()
+                    every { redisTemplate.opsForZSet() } returns zSetOperations
+                    every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns mockTypedTuple
+                    every { zSetOperations.add("rofo:user-report-ranking", "existentNick", 10.0) } returns true
+
+                    then("레디스의 데이터가 정상적으로 업데이트된다.") {
+                        rankingCommandService.updateReportRanking()
+                        verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
+                    }
+                }
+
+                `when`("Lock을 획득하지 못한 경우") {
+                    every { mockLock.tryLock(0, 10, TimeUnit.MINUTES) } returns false
+
+                    then("레디스의 데이터가 업데이트되지 않는다.") {
+                        rankingCommandService.updateReportRanking()
+                        verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
+                    }
+                }
+            }
+        },
+    )

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
@@ -40,14 +40,8 @@ class RankingCommandServiceTest :
                 val zSetOperations = mockk<ZSetOperations<String, String>>()
                 val mockTypedTuple: Set<ZSetOperations.TypedTuple<String>> =
                     setOf(
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user1"
-                            every { score } returns 10.0
-                        },
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user2"
-                            every { score } returns 5.0
-                        },
+                        ZSetOperations.TypedTuple.of("user1", 10.0),
+                        ZSetOperations.TypedTuple.of("user2", 20.0),
                     )
 
                 every { redissonClient.getLock(any<String>()) } returns mockLock
@@ -82,14 +76,8 @@ class RankingCommandServiceTest :
                 val zSetOperations = mockk<ZSetOperations<String, String>>()
                 val mockTypedTuple: Set<ZSetOperations.TypedTuple<String>> =
                     setOf(
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user1"
-                            every { score } returns 10.0
-                        },
-                        mockk<ZSetOperations.TypedTuple<String>>().apply {
-                            every { value } returns "user2"
-                            every { score } returns 5.0
-                        },
+                        ZSetOperations.TypedTuple.of("user1", 10.0),
+                        ZSetOperations.TypedTuple.of("user2", 20.0),
                     )
 
                 every { redissonClient.getLock(any<String>()) } returns mockLock

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kr.weit.roadyfoody.foodSpots.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.springframework.data.redis.core.RedisTemplate
@@ -18,11 +19,13 @@ class RankingCommandServiceTest :
             val redisTemplate = mockk<RedisTemplate<String, String>>()
             val redissonClient = mockk<RedissonClient>()
             val foodSpotsHistoryRepository = mockk<FoodSpotsHistoryRepository>()
+            val reviewRepository = mockk<FoodSpotsReviewRepository>()
             val rankingCommandService =
                 RankingCommandService(
                     redisTemplate,
                     redissonClient,
                     foodSpotsHistoryRepository,
+                    reviewRepository,
                 )
 
             given("updateReportRanking 테스트") {

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -37,4 +37,29 @@ class RankingQueryServiceTest :
                 }
             }
         }
+
+        given("getReviewRanking 테스트") {
+            val zSetOperations = mockk<ZSetOperations<String, String>>()
+            val typedTupleSet =
+                setOf(
+                    mockk<ZSetOperations.TypedTuple<String>> {
+                        every { value } returns "user1"
+                        every { score } returns 10.0
+                    },
+                    mockk<ZSetOperations.TypedTuple<String>> {
+                        every { value } returns "user2"
+                        every { score } returns 20.0
+                    },
+                )
+
+            `when`("레디스의 데이터를 조회한 경우") {
+                every { redisTemplate.opsForZSet() } returns zSetOperations
+                every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns typedTupleSet
+
+                then("리뷰 랭킹이 조회된다.") {
+                    rankingQueryService.getReviewRanking(10)
+                    verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                }
+            }
+        }
     })

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -1,0 +1,40 @@
+package kr.weit.roadyfoody.ranking.application.service
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
+
+class RankingQueryServiceTest :
+    BehaviorSpec({
+
+        val redisTemplate = mockk<RedisTemplate<String, String>>()
+        val rankingQueryService = RankingQueryService(redisTemplate)
+
+        given("getReportRanking 테스트") {
+            val zSetOperations = mockk<ZSetOperations<String, String>>()
+            val typedTupleSet =
+                setOf(
+                    mockk<ZSetOperations.TypedTuple<String>> {
+                        every { value } returns "user1"
+                        every { score } returns 10.0
+                    },
+                    mockk<ZSetOperations.TypedTuple<String>> {
+                        every { value } returns "user2"
+                        every { score } returns 20.0
+                    },
+                )
+
+            `when`("레디스의 데이터를 조회한 경우") {
+                every { redisTemplate.opsForZSet() } returns zSetOperations
+                every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns typedTupleSet
+
+                then("리포트 랭킹이 조회된다.") {
+                    rankingQueryService.getReportRanking(10)
+                    verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -1,9 +1,13 @@
 package kr.weit.roadyfoody.ranking.application.service
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
+import kr.weit.roadyfoody.ranking.fixture.createUserRankingResponse
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.core.ZSetOperations
 
@@ -11,7 +15,9 @@ class RankingQueryServiceTest :
     BehaviorSpec({
 
         val redisTemplate = mockk<RedisTemplate<String, String>>()
-        val rankingQueryService = RankingQueryService(redisTemplate)
+        val foodSpotsHistoryRepository = mockk<FoodSpotsHistoryRepository>()
+        val reviewRepository = mockk<FoodSpotsReviewRepository>()
+        val rankingQueryService = RankingQueryService(redisTemplate, foodSpotsHistoryRepository, reviewRepository)
 
         given("getReportRanking 테스트") {
             val zSetOperations = mockk<ZSetOperations<String, String>>()
@@ -20,6 +26,7 @@ class RankingQueryServiceTest :
                     ZSetOperations.TypedTuple.of("user1", 10.0),
                     ZSetOperations.TypedTuple.of("user2", 20.0),
                 )
+            afterEach { clearMocks(zSetOperations) }
 
             `when`("레디스의 데이터를 조회한 경우") {
                 every { redisTemplate.opsForZSet() } returns zSetOperations
@@ -28,6 +35,19 @@ class RankingQueryServiceTest :
                 then("리포트 랭킹이 조회된다.") {
                     rankingQueryService.getReportRanking(10)
                     verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                }
+            }
+
+            `when`("레디스의 데이터가 조회가 안되는 경우") {
+                every { redisTemplate.opsForZSet() } returns zSetOperations
+                every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns null
+                every { zSetOperations.add("rofo:user-report-ranking", "existentNick", 10.0) } returns true
+                every { foodSpotsHistoryRepository.findAllUserReportCount() } returns createUserRankingResponse()
+
+                then("리포트 랭킹이 조회된다.") {
+                    rankingQueryService.getReportRanking(10)
+                    verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                    verify(exactly = 1) { foodSpotsHistoryRepository.findAllUserReportCount() }
                 }
             }
         }
@@ -40,6 +60,8 @@ class RankingQueryServiceTest :
                     ZSetOperations.TypedTuple.of("user2", 20.0),
                 )
 
+            afterEach { clearMocks(zSetOperations) }
+
             `when`("레디스의 데이터를 조회한 경우") {
                 every { redisTemplate.opsForZSet() } returns zSetOperations
                 every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns typedTupleSet
@@ -47,6 +69,19 @@ class RankingQueryServiceTest :
                 then("리뷰 랭킹이 조회된다.") {
                     rankingQueryService.getReviewRanking(10)
                     verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                }
+            }
+
+            `when`("레디스의 데이터가 조회가 안되는 경우") {
+                every { redisTemplate.opsForZSet() } returns zSetOperations
+                every { zSetOperations.reverseRangeWithScores(any(), any(), any()) } returns null
+                every { zSetOperations.add("rofo:user-review-ranking", "existentNick", 10.0) } returns true
+                every { reviewRepository.findAllUserReviewCount() } returns createUserRankingResponse()
+
+                then("리뷰 랭킹이 조회된다.") {
+                    rankingQueryService.getReviewRanking(10)
+                    verify(exactly = 1) { zSetOperations.reverseRangeWithScores(any(), any(), any()) }
+                    verify(exactly = 1) { reviewRepository.findAllUserReviewCount() }
                 }
             }
         }

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -17,14 +17,8 @@ class RankingQueryServiceTest :
             val zSetOperations = mockk<ZSetOperations<String, String>>()
             val typedTupleSet =
                 setOf(
-                    mockk<ZSetOperations.TypedTuple<String>> {
-                        every { value } returns "user1"
-                        every { score } returns 10.0
-                    },
-                    mockk<ZSetOperations.TypedTuple<String>> {
-                        every { value } returns "user2"
-                        every { score } returns 20.0
-                    },
+                    ZSetOperations.TypedTuple.of("user1", 10.0),
+                    ZSetOperations.TypedTuple.of("user2", 20.0),
                 )
 
             `when`("레디스의 데이터를 조회한 경우") {
@@ -42,14 +36,8 @@ class RankingQueryServiceTest :
             val zSetOperations = mockk<ZSetOperations<String, String>>()
             val typedTupleSet =
                 setOf(
-                    mockk<ZSetOperations.TypedTuple<String>> {
-                        every { value } returns "user1"
-                        every { score } returns 10.0
-                    },
-                    mockk<ZSetOperations.TypedTuple<String>> {
-                        every { value } returns "user2"
-                        every { score } returns 20.0
-                    },
+                    ZSetOperations.TypedTuple.of("user1", 10.0),
+                    ZSetOperations.TypedTuple.of("user2", 20.0),
                 )
 
             `when`("레디스의 데이터를 조회한 경우") {

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/fixture/RankingFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/fixture/RankingFixture.kt
@@ -1,0 +1,16 @@
+package kr.weit.roadyfoody.ranking.fixture
+
+import kr.weit.roadyfoody.ranking.dto.UserRanking
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.fixture.createTestUser
+
+fun createCountResponse(
+    user: User = createTestUser(),
+    total: Long = 10,
+): UserRanking =
+    UserRanking(
+        userNickname = user.profile.nickname,
+        total = total,
+    )
+
+fun createUserRankingResponse(): List<UserRanking> = listOf(createCountResponse())

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
@@ -3,9 +3,9 @@ package kr.weit.roadyfoody.ranking.presentation.api
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
-import kr.weit.roadyfoody.foodSpots.application.service.FoodSpotsCommandService
 import kr.weit.roadyfoody.foodSpots.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.global.TEST_PAGE_SIZE
+import kr.weit.roadyfoody.ranking.application.service.RankingQueryService
 import kr.weit.roadyfoody.support.annotation.ControllerTest
 import kr.weit.roadyfoody.support.utils.getWithAuth
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @WebMvcTest(RankingController::class)
 @ControllerTest
 class RankingControllerTest(
-    @MockkBean private val foodSpotsCommandService: FoodSpotsCommandService,
+    @MockkBean private val rankingQueryService: RankingQueryService,
     private val mockMvc: MockMvc,
 ) : BehaviorSpec(
         {
@@ -24,7 +24,7 @@ class RankingControllerTest(
             given("GET $requestPath/report") {
                 val response = createUserRankingResponse()
                 every {
-                    foodSpotsCommandService.getReportRanking(any())
+                    rankingQueryService.getReportRanking(any())
                 } returns response
                 `when`("정상적인 데이터가 들어올 경우") {
                     then("리포트 랭킹 리스트가 조회된다.") {

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
@@ -3,9 +3,9 @@ package kr.weit.roadyfoody.ranking.presentation.api
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.every
-import kr.weit.roadyfoody.foodSpots.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.global.TEST_PAGE_SIZE
 import kr.weit.roadyfoody.ranking.application.service.RankingQueryService
+import kr.weit.roadyfoody.ranking.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.support.annotation.ControllerTest
 import kr.weit.roadyfoody.support.utils.getWithAuth
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/presentation/api/RankingControllerTest.kt
@@ -46,5 +46,31 @@ class RankingControllerTest(
                     }
                 }
             }
+
+            given("GET $requestPath/review") {
+                val response = createUserRankingResponse()
+                every {
+                    rankingQueryService.getReviewRanking(any())
+                } returns response
+                `when`("정상적인 데이터가 들어올 경우") {
+                    then("리뷰 랭킹 리스트가 조회된다.") {
+                        mockMvc
+                            .perform(
+                                getWithAuth("$requestPath/review")
+                                    .param("size", "$TEST_PAGE_SIZE"),
+                            ).andExpect(status().isOk)
+                    }
+                }
+
+                `when`("size가 음수가 들어올 경우") {
+                    then("400을 반환한다") {
+                        mockMvc
+                            .perform(
+                                getWithAuth("$requestPath/review")
+                                    .param("size", "-1"),
+                            ).andExpect(status().isBadRequest)
+                    }
+                }
+            }
         },
     )

--- a/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
@@ -177,5 +177,17 @@ class FoodSpotsReviewRepositoryTest(
                     }
                 }
             }
+
+            describe("findAllUserReviewCount 메소드는") {
+                it("전체 회원의 닉네임과 리뷰 개수를 정렬하여 리스트로 반환한다") {
+                    val userReportCounts = reviewRepository.findAllUserReviewCount()
+                    userReportCounts.size shouldBe 2
+                    userReportCounts[0].userNickname shouldBe "existentNick"
+                    userReportCounts[0].score shouldBe 3
+
+                    userReportCounts[1].userNickname shouldBe "otherUser"
+                    userReportCounts[1].score shouldBe 1
+                }
+            }
         },
     )

--- a/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
@@ -183,10 +183,10 @@ class FoodSpotsReviewRepositoryTest(
                     val userReportCounts = reviewRepository.findAllUserReviewCount()
                     userReportCounts.size shouldBe 2
                     userReportCounts[0].userNickname shouldBe "existentNick"
-                    userReportCounts[0].score shouldBe 3
+                    userReportCounts[0].total shouldBe 3
 
                     userReportCounts[1].userNickname shouldBe "otherUser"
-                    userReportCounts[1].score shouldBe 1
+                    userReportCounts[1].total shouldBe 1
                 }
             }
         },


### PR DESCRIPTION
### 개요
- 리뷰 개수에 따른 랭킹 구현 
- 리뷰 조회 api 개발 

### 변경사항
- RankingService 추가, 메소드 이동
- 동일 작업 메소드로 분리
- 이용자가 적은 05:00 돌아가도록 스케줄링 작성하였습니다.
  - 스케줄링은 단일 스레드로 동작하기 때문에 동시에 처리되도록 비동기 처리하였습니다. 


### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-182) 


### 리뷰어에게 하고 싶은 말
- 동시간대에 스케줄링 작업되서 업데이트 되기 때문에 하나의 메소드에 적을까 했는데, 분리해놓는게 더 보기 편할 것 같아 분리했습니다. 