### PR TITLE
ROFO-194 사용자 정보 조회 API 반환결과에 뱃지 추가

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
@@ -1,15 +1,14 @@
 package kr.weit.roadyfoody.user.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import kr.weit.roadyfoody.badge.domain.Badge
 
 data class UserInfoResponse(
     @Schema(description = "유저 닉네임", example = "TestNickname")
     val nickname: String,
     @Schema(description = "프로필 URL")
     val profileImageUrl: String?,
-    @Schema(description = "뱃지 정보", example = "BEGINNER")
-    val badge: Badge,
+    @Schema(description = "뱃지 정보", example = "초심자")
+    val badge: String,
     @Schema(description = "보유 중인 코인", example = "100")
     val coin: Int,
     @Schema(description = "잔여 당일 리포트 생성 횟수", example = "3")
@@ -19,7 +18,7 @@ data class UserInfoResponse(
         fun of(
             nickname: String,
             profileImageUrl: String?,
-            badge: Badge,
+            badge: String,
             coin: Int,
             restDailyReportCreationCount: Int,
         ): UserInfoResponse =

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoResponse.kt
@@ -1,12 +1,15 @@
 package kr.weit.roadyfoody.user.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import kr.weit.roadyfoody.badge.domain.Badge
 
 data class UserInfoResponse(
     @Schema(description = "유저 닉네임", example = "TestNickname")
     val nickname: String,
     @Schema(description = "프로필 URL")
     val profileImageUrl: String?,
+    @Schema(description = "뱃지 정보", example = "BEGINNER")
+    val badge: Badge,
     @Schema(description = "보유 중인 코인", example = "100")
     val coin: Int,
     @Schema(description = "잔여 당일 리포트 생성 횟수", example = "3")
@@ -16,12 +19,14 @@ data class UserInfoResponse(
         fun of(
             nickname: String,
             profileImageUrl: String?,
+            badge: Badge,
             coin: Int,
             restDailyReportCreationCount: Int,
         ): UserInfoResponse =
             UserInfoResponse(
                 nickname = nickname,
                 profileImageUrl = profileImageUrl,
+                badge = badge,
                 coin = coin,
                 restDailyReportCreationCount = restDailyReportCreationCount,
             )

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
@@ -50,6 +50,7 @@ class UserQueryService(
         return UserInfoResponse.of(
             user.profile.nickname,
             profileImageUrl,
+            user.badge,
             user.coin,
             restDailyReportCreationCount,
         )

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/service/UserQueryService.kt
@@ -50,7 +50,7 @@ class UserQueryService(
         return UserInfoResponse.of(
             user.profile.nickname,
             profileImageUrl,
-            user.badge,
+            user.badge.description,
             user.coin,
             restDailyReportCreationCount,
         )

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
@@ -24,7 +24,7 @@ fun createTestUserInfoResponse(
 ) = UserInfoResponse(
     nickname = nickname,
     profileImageUrl = profileImageUrl,
-    badge = badge,
+    badge = badge.description,
     coin = coin,
     restDailyReportCreationCount = restDailyReportCreationCount,
 )

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserDtoFixture.kt
@@ -2,6 +2,7 @@ package kr.weit.roadyfoody.user.fixture
 
 import createMockSliceReview
 import createTestReviewPhotoResponse
+import kr.weit.roadyfoody.badge.domain.Badge
 import kr.weit.roadyfoody.common.dto.SliceResponse
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpotsHistory
 import kr.weit.roadyfoody.foodSpots.fixture.TEST_FOOD_SPOTS_PHOTO_URL
@@ -17,11 +18,13 @@ import kr.weit.roadyfoody.user.application.dto.UserReviewResponse
 fun createTestUserInfoResponse(
     nickname: String = TEST_USER_NICKNAME,
     profileImageUrl: String = TEST_USER_PROFILE_IMAGE_URL,
+    badge: Badge = Badge.BEGINNER,
     coin: Int = TEST_USER_COIN,
     restDailyReportCreationCount: Int = TEST_REST_DAILY_REPORT_CREATION_COUNT,
 ) = UserInfoResponse(
     nickname = nickname,
     profileImageUrl = profileImageUrl,
+    badge = badge,
     coin = coin,
     restDailyReportCreationCount = restDailyReportCreationCount,
 )


### PR DESCRIPTION
### 개요
사용자 정보 조회 API 사용 시 사용자의 뱃지 정보를 알 수 있으면 좋을 것 같아 추가합니다.

### 변경사항
- ROFO-194 사용자 정보 조회 API 반환결과에 뱃지 추가


### 테스트
- 테스트 코드 추가여부 X
response dto 에 프로퍼티가 하나 추가되는 단순 작업이였습니다.
기존 테스트 코드로 문제를 예방할 수 있다 생각했습니다.

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-194) 


### 리뷰어에게 하고 싶은 말
모든 피드백 감사히 잘 받겠습니다.