### PR TITLE
[Release/ROFO-218]  로컬캐시 적용/ Redis Pub-sub을 이용하여 로컬캐시 동기화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     implementation("org.opensearch.client:spring-data-opensearch-starter:1.5.1") {
         exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
     }
-    implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.github.ben-manes.caffeine:caffeine")
 
     // Secret & Config

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation("org.opensearch.client:spring-data-opensearch-starter:1.5.1") {
         exclude("org.opensearch.client", "opensearch-rest-client-sniffer")
     }
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
 
     // Secret & Config
     implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1"))

--- a/src/main/kotlin/kr/weit/roadyfoody/global/cache/CachePublisher.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/cache/CachePublisher.kt
@@ -1,0 +1,17 @@
+package kr.weit.roadyfoody.global.cache
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.stereotype.Service
+
+@Service
+class CachePublisher(
+    private val redisTemplate: RedisTemplate<String, String>,
+) {
+    fun publishCacheUpdate(
+        topic: ChannelTopic,
+        key: String,
+    ) {
+        redisTemplate.convertAndSend(topic.topic, key)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/global/cache/CacheSubscriber.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/cache/CacheSubscriber.kt
@@ -1,0 +1,22 @@
+package kr.weit.roadyfoody.global.cache
+
+import org.springframework.cache.CacheManager
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class CacheSubscriber(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val cacheManager: CacheManager,
+) : MessageListener {
+    override fun onMessage(
+        message: Message,
+        pattern: ByteArray?,
+    ) {
+        val key = redisTemplate.stringSerializer.deserialize(message.body) ?: return
+        val value = redisTemplate.opsForList().range(key, 0, -1)
+        cacheManager.getCache(key)?.put(key, value)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/global/config/CacheConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/config/CacheConfig.kt
@@ -1,0 +1,16 @@
+package kr.weit.roadyfoody.global.config
+
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    fun cacheManager(): CaffeineCacheManager =
+        CaffeineCacheManager().apply {
+            isAllowNullValues = false
+        }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/global/config/RedisConfig.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/config/RedisConfig.kt
@@ -1,9 +1,25 @@
 package kr.weit.roadyfoody.global.config
 
+import kr.weit.roadyfoody.global.cache.CacheSubscriber
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisKeyValueAdapter
+import org.springframework.data.redis.listener.PatternTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
-class RedisConfig
+class RedisConfig {
+    @Bean
+    fun redisMessageListener(
+        connectionFactory: RedisConnectionFactory,
+        cacheSubscriber: CacheSubscriber,
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(connectionFactory)
+        container.addMessageListener(cacheSubscriber, PatternTopic("ranking-cache-update"))
+        return container
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -60,7 +60,7 @@ class RankingCommandService(
     }
 
     @Async("asyncTask")
-    @Scheduled(cron = "0 19 15 * * *")
+    @Scheduled(cron = "0 0 5 * * *")
     fun updateTotalRanking() {
         updateRanking(
             lockName = TOTAL_RANKING_UPDATE_LOCK,

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -12,6 +12,7 @@ import kr.weit.roadyfoody.ranking.utils.REVIEW_RANKING_UPDATE_LOCK
 import kr.weit.roadyfoody.ranking.utils.TOTAL_RANKING_KEY
 import kr.weit.roadyfoody.ranking.utils.TOTAL_RANKING_UPDATE_LOCK
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import org.springframework.cache.CacheManager
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
@@ -24,6 +25,7 @@ class RankingQueryService(
     private val reviewRepository: FoodSpotsReviewRepository,
     private val rankingCommandService: RankingCommandService,
     private val executor: ExecutorService,
+    private val cacheManager: CacheManager,
 ) {
     fun getReportRanking(size: Long): List<UserRanking> =
         getRanking(
@@ -63,6 +65,13 @@ class RankingQueryService(
         key: String,
         dataProvider: () -> List<UserRanking>,
     ): List<UserRanking> {
+        val cache = cacheManager.getCache(key)
+        val cachedData =
+            cache?.get(key, List::class.java) as? List<String>
+        if (!cachedData.isNullOrEmpty()) {
+            return convertToUserRanking(cachedData.take(size.toInt()))
+        }
+
         val ranking =
             redisTemplate
                 .opsForList()
@@ -78,15 +87,16 @@ class RankingQueryService(
             }, executor)
             throw RankingNotFoundException()
         }
-        return ranking.map { score ->
-            val data = score.split(":")
-            val userNickname = data[0]
-            val total = data[1]
 
+        return convertToUserRanking(ranking)
+    }
+
+    private fun convertToUserRanking(ranking: List<String>): List<UserRanking> =
+        ranking.map { score ->
+            val (userNickname, total) = score.split(":")
             UserRanking(
                 userNickname = userNickname,
                 total = total.toLong(),
             )
         }
-    }
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:filename")
-
 package kr.weit.roadyfoody.user.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/user/application/dto/UserInfoRequest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:filename")
+
 package kr.weit.roadyfoody.user.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -12,6 +12,8 @@ import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
 import kr.weit.roadyfoody.ranking.exception.RankingNotFoundException
 import kr.weit.roadyfoody.ranking.fixture.createUserRankingResponse
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
 import org.springframework.data.redis.core.ListOperations
 import org.springframework.data.redis.core.RedisTemplate
 import java.util.concurrent.ExecutorService
@@ -24,11 +26,20 @@ class RankingQueryServiceTest :
             val reviewRepository = mockk<FoodSpotsReviewRepository>()
             val rankingCommandService = mockk<RankingCommandService>()
             val executor = mockk<ExecutorService>()
+            val cacheManager = mockk<CacheManager>()
             val rankingQueryService =
-                RankingQueryService(redisTemplate, foodSpotsHistoryRepository, reviewRepository, rankingCommandService, executor)
+                RankingQueryService(
+                    redisTemplate,
+                    foodSpotsHistoryRepository,
+                    reviewRepository,
+                    rankingCommandService,
+                    executor,
+                    cacheManager,
+                )
 
             val listOperation = mockk<ListOperations<String, String>>()
             val list = listOf("user1:10", "user2:20", "user3:15")
+            val cache = mockk<Cache>()
 
             afterEach { clearMocks(reviewRepository) }
             afterEach { clearMocks(listOperation) }
@@ -38,7 +49,18 @@ class RankingQueryServiceTest :
             }
 
             given("getReportRanking 테스트") {
+                `when`("로컬캐시의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns list
+
+                    then("리포트 랭킹이 조회된다.") {
+                        rankingQueryService.getReportRanking(10)
+                        verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                    }
+                }
                 `when`("레디스의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
 
@@ -49,6 +71,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 조회가 안되는 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { listOperation.range(any(), any(), any()) } returns listOf()
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L
                     every { foodSpotsHistoryRepository.findAllUserReportCount() } returns createUserRankingResponse()
@@ -60,7 +84,19 @@ class RankingQueryServiceTest :
             }
 
             given("getReviewRanking 테스트") {
+                `when`("로컬캐시의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns list
+
+                    then("리뷰 랭킹이 조회된다.") {
+                        rankingQueryService.getReviewRanking(10)
+                        verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                    }
+                }
+
                 `when`("레디스의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
 
@@ -71,6 +107,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 조회가 안되는 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns listOf()
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L
@@ -83,7 +121,18 @@ class RankingQueryServiceTest :
             }
 
             given("getLikeRanking 테스트") {
+                `when`("로컬캐시의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns list
+
+                    then("좋아요 랭킹이 조회된다.") {
+                        rankingQueryService.getLikeRanking(10)
+                        verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                    }
+                }
                 `when`("레디스의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
 
@@ -94,6 +143,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 null인 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns null
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L
@@ -105,6 +156,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 빈값인 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns listOf()
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L
@@ -116,8 +169,19 @@ class RankingQueryServiceTest :
                 }
             }
             given("getTotalRanking 테스트") {
+                `when`("로컬캐시의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns list
+
+                    then("종합 랭킹이 조회된다.") {
+                        rankingQueryService.getTotalRanking(10)
+                        verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                    }
+                }
 
                 `when`("레디스의 데이터를 조회한 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
 
@@ -128,6 +192,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 null인 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns null
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L
@@ -154,6 +220,8 @@ class RankingQueryServiceTest :
                 }
 
                 `when`("레디스의 데이터가 빈값인 경우") {
+                    every { cacheManager.getCache(any()) } returns cache
+                    every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns listOf()
                     every { listOperation.rightPushAll(any(), any<List<String>>()) } returns 1L


### PR DESCRIPTION
### 개요
- redis 업데이트시 로컬 캐시도 업데이트하여 랭킹 조회시 로컬 캐시의 데이터를 조회한다. 

### 변경사항
- 로컬캐시로 Caffeine 캐시 적용
- redis pub-sub을 이용하여 새벽 5:00 랭킹 스케줄링 동작시 로컬 캐시도 업데이트 되도록 적용

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-218) 


### 리뷰어에게 하고 싶은 말
모든 피드백 감사히 받겠습니다!  😀