### PR TITLE
ROFO-190 리뷰 신고 API 작성 및 회원탈퇴 시 리뷰 신고 Entity 제거

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/badge/domain/Badge.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/badge/domain/Badge.kt
@@ -16,7 +16,7 @@ enum class Badge(
     ;
 
     companion object {
-        const val HIGH_RATING_CONDITION = 6
+        const val HIGH_RATING_CONDITION = 3
 
         fun getBadge(
             totalReviews: Int,

--- a/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/common/exception/ErrorCode.kt
@@ -103,6 +103,7 @@ enum class ErrorCode(
     NOT_FOUND_FOOD_SPOTS(HttpStatus.NOT_FOUND, -14001, "해당 음식점이 존재하지 않습니다."),
     NOT_FOUND_FOOD_SPOTS_REVIEW(HttpStatus.NOT_FOUND, -14002, "해당 리뷰가 존재하지 않습니다."),
     NOT_FOOD_SPOTS_REVIEW_OWNER(HttpStatus.FORBIDDEN, -14003, "해당 리뷰의 소유자가 아닙니다."),
+    REVIEW_FLAG_ALREADY_EXISTS(HttpStatus.CONFLICT, -14004, "이미 리뷰를 신고하셨습니다."),
 
     // User API error 15000대
     USER_ID_NON_POSITIVE(HttpStatus.BAD_REQUEST, -15000, "유저 ID는 양수여야 합니다."),

--- a/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/swagger/v1/SwaggerTag.kt
@@ -12,5 +12,6 @@ object SwaggerTag {
     const val REWARDS: String = "H. 리워드 API"
     const val RANKING: String = "I. 랭킹 API"
     const val LIKE: String = "J. 좋아요 API"
+    const val REVIEW_FLAG: String = "K. 리뷰 신고 API"
     const val ADMIN: String = "Z. 관리자 API"
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandService.kt
@@ -14,6 +14,7 @@ import kr.weit.roadyfoody.review.domain.FoodSpotsReviewPhoto
 import kr.weit.roadyfoody.review.exception.NotFoodSpotsReviewOwnerException
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewPhotoRepository
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import kr.weit.roadyfoody.review.repository.ReviewFlagRepository
 import kr.weit.roadyfoody.review.repository.ReviewLikeRepository
 import kr.weit.roadyfoody.review.repository.getReviewByReviewId
 import kr.weit.roadyfoody.user.domain.User
@@ -29,6 +30,7 @@ class ReviewCommandService(
     private val reviewPhotoRepository: FoodSpotsReviewPhotoRepository,
     private val foodSpotsRepository: FoodSpotsRepository,
     private val reviewLikeRepository: ReviewLikeRepository,
+    private val reviewFlagRepository: ReviewFlagRepository,
     private val imageService: ImageService,
     private val executor: ExecutorService,
     private val badgeCommandService: BadgeCommandService,
@@ -88,6 +90,7 @@ class ReviewCommandService(
             reviewLikeRepository.deleteByReview(review)
         }
         deleteReviewPhoto(listOf(review))
+        reviewFlagRepository.deleteByReviewId(review.id)
         reviewRepository.delete(review)
     }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/review/application/service/ReviewFlagCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/application/service/ReviewFlagCommandService.kt
@@ -1,0 +1,47 @@
+package kr.weit.roadyfoody.review.application.service
+
+import USER_ENTITY_LOCK_KEY
+import kr.weit.roadyfoody.badge.service.BadgeCommandService
+import kr.weit.roadyfoody.global.annotation.DistributedLock
+import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
+import kr.weit.roadyfoody.review.exception.ReviewFlagAlreadyExistsException
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import kr.weit.roadyfoody.review.repository.ReviewFlagRepository
+import kr.weit.roadyfoody.review.repository.getReviewByReviewId
+import kr.weit.roadyfoody.user.domain.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ReviewFlagCommandService(
+    private val reviewRepository: FoodSpotsReviewRepository,
+    private val reviewFlagRepository: ReviewFlagRepository,
+    private val reviewCommandService: ReviewCommandService,
+    private val badgeCommandService: BadgeCommandService,
+) {
+    companion object {
+        private const val FLAG_THRESHOLD = 4
+    }
+
+    @DistributedLock(lockName = USER_ENTITY_LOCK_KEY, identifier = "user")
+    @Transactional
+    fun flagReview(
+        user: User,
+        reviewId: Long,
+    ) {
+        val reviewFlagsWithLock = reviewFlagRepository.findByReviewId(reviewId)
+
+        if (reviewFlagsWithLock.any { it.user.id == user.id }) {
+            throw ReviewFlagAlreadyExistsException()
+        }
+
+        val review = reviewRepository.getReviewByReviewId(reviewId)
+
+        if (reviewFlagRepository.countByReviewId(review.id) >= FLAG_THRESHOLD) {
+            reviewCommandService.deleteReviewCascade(review.id)
+            badgeCommandService.tryChangeBadgeAndIfPromotedGiveBonus(user.id)
+        } else {
+            reviewFlagRepository.save(FoodSpotsReviewFlag(review = review, user = user))
+        }
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/review/exception/ReviewFlagAlreadyExistsException.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/exception/ReviewFlagAlreadyExistsException.kt
@@ -1,0 +1,8 @@
+package kr.weit.roadyfoody.review.exception
+
+import kr.weit.roadyfoody.common.exception.BaseException
+import kr.weit.roadyfoody.common.exception.ErrorCode
+
+class ReviewFlagAlreadyExistsException(
+    message: String = ErrorCode.REVIEW_FLAG_ALREADY_EXISTS.errorMessage,
+) : BaseException(ErrorCode.REVIEW_FLAG_ALREADY_EXISTS, message)

--- a/src/main/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagController.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagController.kt
@@ -1,0 +1,30 @@
+package kr.weit.roadyfoody.review.presentation.api
+
+import jakarta.validation.constraints.Positive
+import kr.weit.roadyfoody.auth.security.LoginUser
+import kr.weit.roadyfoody.review.application.service.ReviewFlagCommandService
+import kr.weit.roadyfoody.review.presentation.spec.ReviewFlagControllerSpec
+import kr.weit.roadyfoody.user.domain.User
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/reviews/{reviewId}/flag")
+class ReviewFlagController(
+    private val reviewFlagCommandService: ReviewFlagCommandService,
+) : ReviewFlagControllerSpec {
+    @ResponseStatus(CREATED)
+    @PostMapping
+    override fun flagReview(
+        @LoginUser
+        user: User,
+        @Positive(message = "리뷰 ID는 양수여야 합니다.")
+        @PathVariable("reviewId") reviewId: Long,
+    ) {
+        reviewFlagCommandService.flagReview(user, reviewId)
+    }
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/review/presentation/spec/ReviewFlagControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/presentation/spec/ReviewFlagControllerSpec.kt
@@ -15,7 +15,7 @@ interface ReviewFlagControllerSpec {
         description = "리뷰 신고 API",
         responses = [
             ApiResponse(
-                responseCode = "203",
+                responseCode = "201",
                 description = "리뷰 신고 성공",
             ),
         ],

--- a/src/main/kotlin/kr/weit/roadyfoody/review/presentation/spec/ReviewFlagControllerSpec.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/presentation/spec/ReviewFlagControllerSpec.kt
@@ -1,0 +1,35 @@
+package kr.weit.roadyfoody.review.presentation.spec
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Positive
+import kr.weit.roadyfoody.common.exception.ErrorCode
+import kr.weit.roadyfoody.global.swagger.ApiErrorCodeExamples
+import kr.weit.roadyfoody.global.swagger.v1.SwaggerTag
+import kr.weit.roadyfoody.user.domain.User
+
+@Tag(name = SwaggerTag.REVIEW_FLAG)
+interface ReviewFlagControllerSpec {
+    @Operation(
+        description = "리뷰 신고 API",
+        responses = [
+            ApiResponse(
+                responseCode = "203",
+                description = "리뷰 신고 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.REVIEW_ID_NON_POSITIVE,
+            ErrorCode.NOT_FOUND_FOOD_SPOTS_REVIEW,
+            ErrorCode.REVIEW_FLAG_ALREADY_EXISTS,
+        ],
+    )
+    fun flagReview(
+        user: User,
+        @Positive(message = "리뷰 ID는 양수여야 합니다.")
+        reviewId: Long,
+    )
+}

--- a/src/main/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepository.kt
@@ -1,15 +1,15 @@
 package kr.weit.roadyfoody.review.repository
 
-import jakarta.persistence.LockModeType
 import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
 
 interface ReviewFlagRepository : JpaRepository<FoodSpotsReviewFlag, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    fun findByReviewId(reviewId: Long): List<FoodSpotsReviewFlag>
-
     fun countByReviewId(reviewId: Long): Int
+
+    fun existsByReviewIdAndUserId(
+        reviewId: Long,
+        userId: Long,
+    ): Boolean
 
     fun deleteByReviewId(reviewId: Long)
 }

--- a/src/main/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepository.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepository.kt
@@ -1,0 +1,15 @@
+package kr.weit.roadyfoody.review.repository
+
+import jakarta.persistence.LockModeType
+import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+
+interface ReviewFlagRepository : JpaRepository<FoodSpotsReviewFlag, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findByReviewId(reviewId: Long): List<FoodSpotsReviewFlag>
+
+    fun countByReviewId(reviewId: Long): Int
+
+    fun deleteByReviewId(reviewId: Long)
+}

--- a/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandServiceTest.kt
@@ -27,6 +27,7 @@ import kr.weit.roadyfoody.review.exception.FoodSpotsReviewNotFoundException
 import kr.weit.roadyfoody.review.exception.NotFoodSpotsReviewOwnerException
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewPhotoRepository
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import kr.weit.roadyfoody.review.repository.ReviewFlagRepository
 import kr.weit.roadyfoody.review.repository.ReviewLikeRepository
 import kr.weit.roadyfoody.review.repository.getReviewByReviewId
 import kr.weit.roadyfoody.support.utils.ImageFormat
@@ -42,6 +43,7 @@ class ReviewCommandServiceTest :
             val reviewPhotoRepository = mockk<FoodSpotsReviewPhotoRepository>()
             val foodSpotsRepository = mockk<FoodSpotsRepository>()
             val reviewLikeRepository = mockk<ReviewLikeRepository>()
+            val reviewFlagRepository = mockk<ReviewFlagRepository>()
             val imageService = spyk(ImageService(mockk()))
             val executor = mockk<ExecutorService>()
             val badgeCommandService = mockk<BadgeCommandService>()
@@ -52,6 +54,7 @@ class ReviewCommandServiceTest :
                         reviewPhotoRepository,
                         foodSpotsRepository,
                         reviewLikeRepository,
+                        reviewFlagRepository,
                         imageService,
                         executor,
                         badgeCommandService,
@@ -146,6 +149,7 @@ class ReviewCommandServiceTest :
                 every { reviewRepository.getReviewByReviewId(any()) } returns createMockTestReview()
                 every { reviewLikeRepository.deleteByReview(any()) } returns Unit
                 every { reviewService["deleteReviewPhoto"](any<List<FoodSpotsReview>>()) } returns Unit
+                every { reviewFlagRepository.deleteByReviewId(any()) } returns Unit
                 every { reviewRepository.delete(any()) } returns Unit
                 `when`("정상적인 삭제 요청이 들어올 경우") {
                     then("정상적으로 삭제되어야 한다.") {
@@ -153,6 +157,7 @@ class ReviewCommandServiceTest :
                         verify(exactly = 1) {
                             reviewLikeRepository.deleteByReview(any())
                             reviewService["deleteReviewPhoto"](any<List<FoodSpotsReview>>())
+                            reviewFlagRepository.deleteByReviewId(any())
                             reviewRepository.delete(any())
                         }
                     }

--- a/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewCommandServiceTest.kt
@@ -20,6 +20,7 @@ import kr.weit.roadyfoody.foodSpots.fixture.createMockTestFoodSpot
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsRepository
 import kr.weit.roadyfoody.foodSpots.repository.getByFoodSpotsId
 import kr.weit.roadyfoody.global.service.ImageService
+import kr.weit.roadyfoody.review.domain.FoodSpotsReview
 import kr.weit.roadyfoody.review.domain.FoodSpotsReviewPhoto
 import kr.weit.roadyfoody.review.exception.FoodSpotsNotFoundException
 import kr.weit.roadyfoody.review.exception.FoodSpotsReviewNotFoundException
@@ -45,14 +46,17 @@ class ReviewCommandServiceTest :
             val executor = mockk<ExecutorService>()
             val badgeCommandService = mockk<BadgeCommandService>()
             val reviewService =
-                ReviewCommandService(
-                    reviewRepository,
-                    reviewPhotoRepository,
-                    foodSpotsRepository,
-                    reviewLikeRepository,
-                    imageService,
-                    executor,
-                    badgeCommandService,
+                spyk(
+                    ReviewCommandService(
+                        reviewRepository,
+                        reviewPhotoRepository,
+                        foodSpotsRepository,
+                        reviewLikeRepository,
+                        imageService,
+                        executor,
+                        badgeCommandService,
+                    ),
+                    recordPrivateCalls = true,
                 )
             afterEach { clearAllMocks() }
 
@@ -99,8 +103,7 @@ class ReviewCommandServiceTest :
                         createTestReviewPhoto(),
                     )
                 every { imageService.remove(any()) } returns Unit
-                every { reviewRepository.deleteAll(any()) } returns Unit
-                every { reviewPhotoRepository.deleteAll(any()) } returns Unit
+                every { reviewService.deleteReviewCascade(any()) } returns Unit
                 `when`("정상적인 삭제 요청이 들어올 경우") {
                     then("정상적으로 삭제되어야 한다.") {
                         reviewService.deleteWithdrewUserReview(createTestUser())
@@ -124,22 +127,32 @@ class ReviewCommandServiceTest :
                         createMockTestReview(
                             user,
                         )
-                    every { reviewLikeRepository.deleteByReview(any()) } returns Unit
-                    every { reviewRepository.deleteById(any()) } returns Unit
                     every { reviewPhotoRepository.findByFoodSpotsReviewIn(any()) } returns
                         listOf(
                             createTestReviewPhoto(),
                         )
-                    every { imageService.remove(any()) } returns Unit
-                    every { reviewPhotoRepository.deleteAll(any()) } returns Unit
-                    every { reviewRepository.delete(any()) } returns Unit
+                    every { reviewService.deleteReviewCascade(any()) } returns Unit
                     every { badgeCommandService.tryChangeBadgeAndIfPromotedGiveBonus(any()) } just runs
                     then("정상적으로 삭제되어야 한다.") {
                         reviewService.deleteReview(user, TEST_REVIEW_ID)
                         verify(exactly = 1) {
-                            imageService.remove(any())
+                            reviewService.deleteReviewCascade(any())
+                        }
+                    }
+                }
+            }
+
+            given("deleteReviewCascade 테스트") {
+                every { reviewRepository.getReviewByReviewId(any()) } returns createMockTestReview()
+                every { reviewLikeRepository.deleteByReview(any()) } returns Unit
+                every { reviewService["deleteReviewPhoto"](any<List<FoodSpotsReview>>()) } returns Unit
+                every { reviewRepository.delete(any()) } returns Unit
+                `when`("정상적인 삭제 요청이 들어올 경우") {
+                    then("정상적으로 삭제되어야 한다.") {
+                        reviewService.deleteReviewCascade(TEST_REVIEW_ID)
+                        verify(exactly = 1) {
                             reviewLikeRepository.deleteByReview(any())
-                            reviewPhotoRepository.deleteAll(any())
+                            reviewService["deleteReviewPhoto"](any<List<FoodSpotsReview>>())
                             reviewRepository.delete(any())
                         }
                     }

--- a/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewFlagCommandServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/application/service/ReviewFlagCommandServiceTest.kt
@@ -1,0 +1,83 @@
+package kr.weit.roadyfoody.review.application.service
+
+import TEST_REVIEW_ID
+import createMockTestReview
+import createTestReviewFlag
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.weit.roadyfoody.badge.service.BadgeCommandService
+import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
+import kr.weit.roadyfoody.review.exception.ReviewFlagAlreadyExistsException
+import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import kr.weit.roadyfoody.review.repository.ReviewFlagRepository
+import kr.weit.roadyfoody.user.fixture.createTestUser
+import java.util.Optional
+
+class ReviewFlagCommandServiceTest :
+    BehaviorSpec({
+        val reviewRepository = mockk<FoodSpotsReviewRepository>()
+        val reviewFlagRepository = mockk<ReviewFlagRepository>()
+        val reviewCommandService = mockk<ReviewCommandService>()
+        val badgeCommandService = mockk<BadgeCommandService>()
+        val reviewFlagCommandService =
+            ReviewFlagCommandService(
+                reviewRepository,
+                reviewFlagRepository,
+                reviewCommandService,
+                badgeCommandService,
+            )
+
+        val user = createTestUser()
+
+        afterEach { clearAllMocks() }
+
+        given("flagReview 테스트") {
+            `when`("정상적인 요청일 시 ") {
+                every { reviewFlagRepository.findByReviewId(any()) } returns listOf()
+                every { reviewRepository.findById(any()) } returns Optional.of(createMockTestReview())
+                every { reviewFlagRepository.save(any()) } returns
+                    FoodSpotsReviewFlag(review = createMockTestReview(), user = createTestUser())
+                every { reviewFlagRepository.countByReviewId(any()) } returns 3
+
+                then("리뷰신고 저장을 성공한다.") {
+                    reviewFlagCommandService.flagReview(user, TEST_REVIEW_ID)
+
+                    verify(exactly = 1) { reviewFlagRepository.save(any()) }
+                }
+            }
+
+            `when`("이미 신고를 한 경우") {
+                every { reviewFlagRepository.findByReviewId(any()) } returns
+                    listOf(FoodSpotsReviewFlag(review = createMockTestReview(), user = user))
+
+                then("예외가 발생한다.") {
+                    shouldThrow<ReviewFlagAlreadyExistsException> {
+                        reviewFlagCommandService.flagReview(user, TEST_REVIEW_ID)
+                    }
+                }
+            }
+
+            `when`("신고 임계값을 초과하는 경우") {
+                every { reviewFlagRepository.findByReviewId(any()) } returns listOf()
+                every { reviewRepository.findById(any()) } returns Optional.of(createMockTestReview())
+                every { reviewFlagRepository.save(any()) } returns createTestReviewFlag()
+                every { reviewFlagRepository.countByReviewId(any()) } returns 4
+                every { reviewCommandService.deleteReviewCascade(any()) } returns Unit
+                every { badgeCommandService.tryChangeBadgeAndIfPromotedGiveBonus(any()) } returns Unit
+
+                then("해당 리뷰 제거에 성공한다.") {
+                    reviewFlagCommandService.flagReview(user, TEST_REVIEW_ID)
+
+                    verify(exactly = 1) {
+                        reviewFlagRepository.countByReviewId(any())
+                        reviewCommandService.deleteReviewCascade(any())
+                        badgeCommandService.tryChangeBadgeAndIfPromotedGiveBonus(any())
+                    }
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/review/fixture/ReviewFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/fixture/ReviewFixture.kt
@@ -9,6 +9,7 @@ import kr.weit.roadyfoody.review.application.dto.ReviewRequest
 import kr.weit.roadyfoody.review.application.dto.ReviewUpdateRequest
 import kr.weit.roadyfoody.review.application.dto.ToggleLikeResponse
 import kr.weit.roadyfoody.review.domain.FoodSpotsReview
+import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
 import kr.weit.roadyfoody.review.domain.FoodSpotsReviewPhoto
 import kr.weit.roadyfoody.review.domain.ReviewLike
 import kr.weit.roadyfoody.user.application.dto.UserLikedReviewResponse
@@ -145,3 +146,8 @@ class MockTestReviewLike(
 ) : ReviewLike(id, review, user) {
     override var createdDateTime: LocalDateTime = LocalDateTime.now()
 }
+
+fun createTestReviewFlag(
+    review: FoodSpotsReview = createMockTestReview(),
+    user: User = createTestUser(),
+) = FoodSpotsReviewFlag(review = review, user = user)

--- a/src/test/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagControllerTest.kt
@@ -1,0 +1,44 @@
+package kr.weit.roadyfoody.review.presentation.api
+
+import TEST_REVIEW_ID
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import kr.weit.roadyfoody.review.application.service.ReviewFlagCommandService
+import kr.weit.roadyfoody.support.annotation.ControllerTest
+import kr.weit.roadyfoody.support.utils.postWithAuth
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(ReviewFlagController::class)
+@ControllerTest
+class ReviewFlagControllerTest(
+    private val mockMvc: MockMvc,
+    @MockkBean private val reviewFlagCommandService: ReviewFlagCommandService,
+) : BehaviorSpec({
+        val requestPath = "/api/v1/reviews"
+
+        given("POST $requestPath/{reviewId}/flag") {
+            every { reviewFlagCommandService.flagReview(any(), any()) } just runs
+            `when`("정상적인 데이터가 들어올 경우") {
+                then("리뷰 신고가 성공하고 203 반환") {
+                    mockMvc
+                        .perform(
+                            postWithAuth("$requestPath/$TEST_REVIEW_ID/flag"),
+                        ).andExpect(status().isCreated)
+                }
+            }
+
+            `when`("리뷰 id가 양수가 아닌 경우") {
+                then("400 반환") {
+                    mockMvc
+                        .perform(
+                            postWithAuth("$requestPath/-1/flag"),
+                        ).andExpect(status().isBadRequest)
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagControllerTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/presentation/api/ReviewFlagControllerTest.kt
@@ -24,7 +24,7 @@ class ReviewFlagControllerTest(
         given("POST $requestPath/{reviewId}/flag") {
             every { reviewFlagCommandService.flagReview(any(), any()) } just runs
             `when`("정상적인 데이터가 들어올 경우") {
-                then("리뷰 신고가 성공하고 203 반환") {
+                then("리뷰 신고가 성공하고 201 반환") {
                     mockMvc
                         .perform(
                             postWithAuth("$requestPath/$TEST_REVIEW_ID/flag"),

--- a/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/repository/FoodSpotsReviewRepositoryTest.kt
@@ -72,6 +72,14 @@ class FoodSpotsReviewRepositoryTest(
                 }
             }
 
+            describe("findReviewById 메소드는") {
+                context("리뷰 ID를 받는 경우") {
+                    it("해당 ID의 리뷰를 반환한다.") {
+                        reviewRepository.findReviewById(reviewList.first().id) shouldBe reviewList.first()
+                    }
+                }
+            }
+
             describe("deleteAll 메소드는") {
                 context("삭제할 리스트를 받는 경우") {
                     it("해당 리스트 모두 삭제한다.") {
@@ -81,6 +89,7 @@ class FoodSpotsReviewRepositoryTest(
                     }
                 }
             }
+
             describe("getReviewByReviewId 메소드는") {
                 context("리뷰 ID를 받는 경우") {
                     it("해당 ID의 리뷰를 반환한다.") {
@@ -92,6 +101,22 @@ class FoodSpotsReviewRepositoryTest(
                     it("에러가 발생한다") {
                         shouldThrow<FoodSpotsReviewNotFoundException> {
                             reviewRepository.getReviewByReviewId(0L)
+                        }
+                    }
+                }
+            }
+
+            describe("getByIdWithPessimisticLock 메소드는") {
+                context("리뷰 ID를 받는 경우") {
+                    it("해당 ID의 리뷰를 반환한다.") {
+                        reviewRepository.getByIdWithPessimisticLock(reviewList.first().id) shouldBe reviewList.first()
+                    }
+                }
+
+                context("존재하지 않는 리뷰 ID 를 받는 경우") {
+                    it("에러가 발생한다") {
+                        shouldThrow<FoodSpotsReviewNotFoundException> {
+                            reviewRepository.getByIdWithPessimisticLock(0L)
                         }
                     }
                 }

--- a/src/test/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepositoryTest.kt
@@ -3,8 +3,7 @@ package kr.weit.roadyfoody.review.repository
 import createTestFoodSpotsReview
 import createTestReviewFlag
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldContainAll
-import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.ints.shouldBeZero
 import io.kotest.matchers.shouldBe
 import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
@@ -36,20 +35,19 @@ class ReviewFlagRepositoryTest(
                 reviewFlags = reviewFlagRepository.saveAll(users.map { createTestReviewFlag(review, it) })
             }
 
-            describe("findByReviewId") {
-                it("리뷰 ID로 리뷰 신고를 조회한다.") {
-                    val actualReviewFlags = reviewFlagRepository.findByReviewId(review.id)
-
-                    actualReviewFlags.shouldContainAll(reviewFlags)
-                    actualReviewFlags.shouldHaveSize(reviewFlags.size)
-                }
-            }
-
             describe("countByReviewId") {
                 it("리뷰 ID로 리뷰 신고 수를 조회한다.") {
                     val count = reviewFlagRepository.countByReviewId(review.id)
 
                     count shouldBe reviewFlags.size
+                }
+            }
+
+            describe("existsByReviewIdAndUserId") {
+                it("리뷰 ID와 사용자 ID로 리뷰 신고가 존재하는지 확인한다.") {
+                    val exists = reviewFlagRepository.existsByReviewIdAndUserId(review.id, users[0].id)
+
+                    exists.shouldBeTrue()
                 }
             }
 

--- a/src/test/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepositoryTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/review/repository/ReviewFlagRepositoryTest.kt
@@ -1,0 +1,65 @@
+package kr.weit.roadyfoody.review.repository
+
+import createTestFoodSpotsReview
+import createTestReviewFlag
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeZero
+import io.kotest.matchers.shouldBe
+import kr.weit.roadyfoody.foodSpots.domain.FoodSpots
+import kr.weit.roadyfoody.foodSpots.fixture.createTestFoodSpots
+import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsRepository
+import kr.weit.roadyfoody.review.domain.FoodSpotsReview
+import kr.weit.roadyfoody.review.domain.FoodSpotsReviewFlag
+import kr.weit.roadyfoody.support.annotation.RepositoryTest
+import kr.weit.roadyfoody.user.domain.User
+import kr.weit.roadyfoody.user.fixture.createTestUsers
+import kr.weit.roadyfoody.user.repository.UserRepository
+
+@RepositoryTest
+class ReviewFlagRepositoryTest(
+    private val userRepository: UserRepository,
+    private val foodSpotsRepository: FoodSpotsRepository,
+    private val reviewRepository: FoodSpotsReviewRepository,
+    private val reviewFlagRepository: ReviewFlagRepository,
+) : DescribeSpec(
+        {
+            lateinit var users: List<User>
+            lateinit var foodSpots: FoodSpots
+            lateinit var review: FoodSpotsReview
+            lateinit var reviewFlags: List<FoodSpotsReviewFlag>
+            beforeEach {
+                users = userRepository.saveAll(createTestUsers(3))
+                foodSpots = foodSpotsRepository.save(createTestFoodSpots())
+                review = reviewRepository.save(createTestFoodSpotsReview(foodSpots = foodSpots, user = users[0]))
+                reviewFlags = reviewFlagRepository.saveAll(users.map { createTestReviewFlag(review, it) })
+            }
+
+            describe("findByReviewId") {
+                it("리뷰 ID로 리뷰 신고를 조회한다.") {
+                    val actualReviewFlags = reviewFlagRepository.findByReviewId(review.id)
+
+                    actualReviewFlags.shouldContainAll(reviewFlags)
+                    actualReviewFlags.shouldHaveSize(reviewFlags.size)
+                }
+            }
+
+            describe("countByReviewId") {
+                it("리뷰 ID로 리뷰 신고 수를 조회한다.") {
+                    val count = reviewFlagRepository.countByReviewId(review.id)
+
+                    count shouldBe reviewFlags.size
+                }
+            }
+
+            describe("deleteByReviewId") {
+                it("리뷰 ID로 리뷰 신고를 삭제한다.") {
+                    reviewFlagRepository.deleteByReviewId(review.id)
+
+                    val count = reviewFlagRepository.countByReviewId(review.id)
+                    count.shouldBeZero()
+                }
+            }
+        },
+    )

--- a/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/user/fixture/UserFixture.kt
@@ -40,7 +40,7 @@ fun createTestUser(
     badge,
 )
 
-fun createTestUsers(size: Int = 5) = List(size) { createTestUser(it.toLong() + 1) }
+fun createTestUsers(size: Int = 5) = List(size) { createTestUser(it.toLong() + 1, nickname = "$TEST_USER_NICKNAME$it") }
 
 fun createTestUserNicknameRequest(nickname: String = TEST_USER_NICKNAME) = UserNicknameRequest(nickname)
 


### PR DESCRIPTION
### 개요
리뷰 신고 API 를 작성합니다.  
신고 기능 작성에 앞서 review 삭제 시 review 를 외래키로 가지는 Entity 를 같이 삭제해주는 메소드 추출 (메소드명 : deleteReviewCascade)
회원탈퇴 시 리뷰 신고 Entity를 제거합니다.

### 변경사항
- Badge 승급 기준 평점 변경 (6점 -> 3점, 평점 범위 최대 10점에서 5점으로 변경된 것에 대한 수정)
- deleteReviewCascade 메소드 추출
- 리뷰 신고 API 작성

### 테스트
- 테스트 코드 추가여부 O

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-190) 

### 리뷰어에게 하고 싶은 말
DB 에서 cascade 걸어주듯 애플리케이션 로직에서 순수하게 review entity 제거 시 
review 를 외래키로 가지는 entity(ReviewPhotos, ReviewLikes, ReviewFlags) 들을 같이 삭제해주는 메소드를 추출했습니다.
(메소드명 : deleteReviewCascade)

회원탈퇴 시 리뷰 신고 Entity 를 제거하는 작업이 [다른 작업](https://weit-2nd.atlassian.net/browse/ROFO-191)인데 이번 PR 에 추가했습니다. 이렇게 메소드를 추출하고 나니 회원탈퇴 변경 작업도 너무 단순해져서 추가했습니다.

모든 피드백 감사히 잘 받겠습니다.