### PR TITLE
[feature/ROFO-239] 랭킹 리스트 - 프로필 이미지 url, 랭킹 변동값 수정

### DIFF
--- a/src/main/kotlin/kr/weit/roadyfoody/global/service/StorageService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/global/service/StorageService.kt
@@ -24,12 +24,12 @@ class StorageService(
     fun downloadUrl(key: String): String {
         val cacheKey = getObjectStorageCacheKey(key)
         if (redisTemplate.hasKey(cacheKey)) {
-            return redisTemplate.opsForValue().get(cacheKey)!!
+            return redisTemplate.opsForValue().get(cacheKey)!!.split("?")[0]
         } else {
             val url = s3Template.createSignedGetURL(s3Properties.bucket, key, CACHE_DURATION).toString()
             // 캐싱시간은 실제 파일의 생명주기보다 살짝 짧아야한다
             redisTemplate.opsForValue().set(cacheKey, url, CACHE_DURATION.minusMinutes(30))
-            return url
+            return url.split("?")[0]
         }
     }
 

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingCommandService.kt
@@ -102,7 +102,9 @@ class RankingCommandService(
                         splitRanking
                             ?.indexOfFirst { parts ->
                                 parts[2] == it.userId.toString()
-                            }?.minus(index)
+                            }?.let { result ->
+                                if (result == -1) 0 else result - index
+                            }
 
                     "${index + 1}:${it.userNickname}:${it.userId}:${it.profileImageUrl}:$rankChange"
                 }

--- a/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
+++ b/src/main/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryService.kt
@@ -3,6 +3,7 @@ package kr.weit.roadyfoody.ranking.application.service
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
 import kr.weit.roadyfoody.global.circuitbreaker.targetexception.REDIS_CIRCUIT_BREAKER_TARGET_EXCEPTIONS
+import kr.weit.roadyfoody.global.service.ImageService
 import kr.weit.roadyfoody.ranking.dto.UserRanking
 import kr.weit.roadyfoody.ranking.dto.UserRankingResponse
 import kr.weit.roadyfoody.ranking.exception.RankingNotFoundException
@@ -29,6 +30,7 @@ class RankingQueryService(
     private val rankingCommandService: RankingCommandService,
     private val executor: ExecutorService,
     private val cacheManager: CacheManager,
+    private val imageService: ImageService,
 ) {
     @CircuitBreaker(name = "redisCircuitBreaker", fallbackMethod = "fallbackRankings")
     fun getReportRanking(
@@ -117,7 +119,12 @@ class RankingQueryService(
 
     private fun convertToUserRanking(ranking: List<String>): List<UserRankingResponse> =
         ranking.map { score ->
-            val (ranking, userNickname, userId, profileImageUrl, rankChange) = score.split(":")
+            val (ranking, userNickname, userId, profileImage, rankChange) = score.split(":")
+            val profileImageUrl =
+                profileImage.takeIf { it != "null" }?.let {
+                    imageService.getDownloadUrl(it)
+                }
+
             UserRankingResponse(
                 ranking = ranking.toLong(),
                 userNickname = userNickname,

--- a/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
+++ b/src/test/kotlin/kr/weit/roadyfoody/ranking/application/service/RankingQueryServiceTest.kt
@@ -11,9 +11,11 @@ import io.mockk.verify
 import kr.weit.roadyfoody.foodSpots.repository.FoodSpotsHistoryRepository
 import kr.weit.roadyfoody.global.TEST_SIZE
 import kr.weit.roadyfoody.global.TEST_START_INDEX
+import kr.weit.roadyfoody.global.service.ImageService
 import kr.weit.roadyfoody.ranking.exception.RankingNotFoundException
 import kr.weit.roadyfoody.ranking.fixture.createUserRanking
 import kr.weit.roadyfoody.review.repository.FoodSpotsReviewRepository
+import kr.weit.roadyfoody.user.fixture.TEST_USER_PROFILE_IMAGE_URL
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
 import org.springframework.data.redis.core.ListOperations
@@ -29,6 +31,7 @@ class RankingQueryServiceTest :
             val rankingCommandService = mockk<RankingCommandService>()
             val executor = mockk<ExecutorService>()
             val cacheManager = mockk<CacheManager>()
+            val imageService = mockk<ImageService>()
             val rankingQueryService =
                 RankingQueryService(
                     redisTemplate,
@@ -37,6 +40,7 @@ class RankingQueryServiceTest :
                     rankingCommandService,
                     executor,
                     cacheManager,
+                    imageService,
                 )
 
             val listOperation = mockk<ListOperations<String, String>>()
@@ -46,6 +50,8 @@ class RankingQueryServiceTest :
             afterEach { clearMocks(reviewRepository) }
             afterEach { clearMocks(listOperation) }
             afterEach { clearMocks(rankingCommandService) }
+            afterEach { clearMocks(imageService) }
+            afterEach { clearMocks(imageService) }
             every { executor.execute(any()) } answers {
                 firstArg<Runnable>().run()
             }
@@ -54,10 +60,12 @@ class RankingQueryServiceTest :
                 `when`("로컬캐시의 데이터를 조회한 경우") {
                     every { cacheManager.getCache(any()) } returns cache
                     every { cache.get(any(), List::class.java) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("리포트 랭킹이 조회된다.") {
                         rankingQueryService.getReportRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
                 `when`("레디스의 데이터를 조회한 경우") {
@@ -65,10 +73,12 @@ class RankingQueryServiceTest :
                     every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("리포트 랭킹이 조회된다.") {
                         rankingQueryService.getReportRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 1) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 
@@ -89,10 +99,12 @@ class RankingQueryServiceTest :
                 `when`("로컬캐시의 데이터를 조회한 경우") {
                     every { cacheManager.getCache(any()) } returns cache
                     every { cache.get(any(), List::class.java) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("리뷰 랭킹이 조회된다.") {
                         rankingQueryService.getReviewRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 
@@ -101,10 +113,12 @@ class RankingQueryServiceTest :
                     every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("리뷰 랭킹이 조회된다.") {
                         rankingQueryService.getReviewRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 1) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 
@@ -126,10 +140,12 @@ class RankingQueryServiceTest :
                 `when`("로컬캐시의 데이터를 조회한 경우") {
                     every { cacheManager.getCache(any()) } returns cache
                     every { cache.get(any(), List::class.java) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("좋아요 랭킹이 조회된다.") {
                         rankingQueryService.getLikeRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
                 `when`("레디스의 데이터를 조회한 경우") {
@@ -137,10 +153,12 @@ class RankingQueryServiceTest :
                     every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("리뷰 랭킹이 조회된다.") {
                         rankingQueryService.getLikeRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 1) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 
@@ -174,10 +192,12 @@ class RankingQueryServiceTest :
                 `when`("로컬캐시의 데이터를 조회한 경우") {
                     every { cacheManager.getCache(any()) } returns cache
                     every { cache.get(any(), List::class.java) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("종합 랭킹이 조회된다.") {
                         rankingQueryService.getTotalRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 0) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 
@@ -186,10 +206,12 @@ class RankingQueryServiceTest :
                     every { cache.get(any(), List::class.java) } returns null
                     every { redisTemplate.opsForList() } returns listOperation
                     every { listOperation.range(any(), any(), any()) } returns list
+                    every { imageService.getDownloadUrl(any()) } returns TEST_USER_PROFILE_IMAGE_URL
 
                     then("종합 랭킹이 조회된다.") {
                         rankingQueryService.getTotalRanking(TEST_SIZE, TEST_START_INDEX)
                         verify(exactly = 1) { listOperation.range(any(), any(), any()) }
+                        verify(exactly = 2) { imageService.getDownloadUrl(any()) }
                     }
                 }
 


### PR DESCRIPTION
### 개요
- 랭킹 리스트에 이미지, 랭킹 변동값을 잘 못 내려주고 있어서 수정하였습니다! 

### 변경사항
- 이미지 경로 수정 
- 랭킹 데이터가 없을 경우 랭킹 변동값 0을 내려주도록 수정
- 이미지 경로 파라미터가 없어도 이미지가 제대로 보여지고 있어서 파라미터 없이 내려주도록 수정

### 테스트
- 테스트 코드 추가여부 X
- 기존 테스트 코드 수정

### 관련 지라 및 위키 링크
 - [JIRA](https://weit-2nd.atlassian.net/browse/ROFO-239) 


### 리뷰어에게 하고 싶은 말
랭킹 데이터가 없는 경우에 랭킹 변동값 0을 내려주도록 임시로 수정하였습니다. 
근본적인 원인은 데이터가 왜 안 들어가는지 파악을 해야하는데, 어제 배포 후 스케줄링 동작하도록 몇 번 테스트 했는데 제대로 동작해서...
이건 좀 더 봐야할 것 같아서 우선 임시로 수정하였습니다! 